### PR TITLE
feat(pages): add CSS styling to individual pages

### DIFF
--- a/docs/inventories/inv00001.html
+++ b/docs/inventories/inv00001.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ASL (LQ_1)</title>
+  <title>Inventory: ASL (LQ_1)</title>
   
 <style>
 @font-face {
@@ -12,501 +12,723 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>ASL (LQ_1)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00001</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>ASL (LQ_1)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>American Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>LQ_1</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Longqian Ming</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: ASL (LQ_1)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00001</td>
+<td class="col-language-name">American Sign Language</td>
+<td class="col-contributor">Longqian Ming</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00004.html">S203</a></td>
-<td class="signwriting">񆄱</td>
-<td class="signwriting">񆅁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00004.html">S203</a></td>
+<td class="signwriting col-signwriting-1">񆄱</td>
+<td class="signwriting col-signwriting-2">񆅁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00058.html">S112</a></td>
-<td class="signwriting">񀛑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00058.html">S112</a></td>
+<td class="signwriting col-signwriting-1">񀛑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>extended</td>
-<td><a href="../segments/seg00073.html">S1ab</a></td>
-<td class="signwriting">񄀱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00073.html">S1ab</a></td>
+<td class="signwriting col-signwriting-1">񄀱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00082.html">S14b</a></td>
-<td class="signwriting">񁰱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00082.html">S14b</a></td>
+<td class="signwriting col-signwriting-1">񁰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00090.html">S202</a></td>
-<td class="signwriting">񆃑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00090.html">S202</a></td>
+<td class="signwriting col-signwriting-1">񆃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00094.html">S146</a></td>
-<td class="signwriting">񁩑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00094.html">S146</a></td>
+<td class="signwriting col-signwriting-1">񁩑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00141.html">S1a4</a></td>
-<td class="signwriting">񃶁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00141.html">S1a4</a></td>
+<td class="signwriting col-signwriting-1">񃶁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00002.html
+++ b/docs/inventories/inv00002.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>CSL, ZGS (LQ_2)</title>
+  <title>Inventory: CSL, ZGS (LQ_2)</title>
   
 <style>
 @font-face {
@@ -12,591 +12,813 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>CSL, ZGS (LQ_2)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00002</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>CSL, ZGS (LQ_2)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Chinese Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>LQ_2</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Longqian Ming</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: CSL, ZGS (LQ_2)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00002</td>
+<td class="col-language-name">Chinese Sign Language</td>
+<td class="col-contributor">Longqian Ming</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00004.html">S203</a></td>
-<td class="signwriting">񆄱</td>
-<td class="signwriting">񆅁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00004.html">S203</a></td>
+<td class="signwriting col-signwriting-1">񆄱</td>
+<td class="signwriting col-signwriting-2">񆅁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00007.html">S1fc</a></td>
-<td class="signwriting">񅺡</td>
-<td class="signwriting">񅺑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00007.html">S1fc</a></td>
+<td class="signwriting col-signwriting-1">񅺡</td>
+<td class="signwriting col-signwriting-2">񅺑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00008.html">S1fd</a></td>
-<td class="signwriting">񅼁</td>
-<td class="signwriting">񅻱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00008.html">S1fd</a></td>
+<td class="signwriting col-signwriting-1">񅼁</td>
+<td class="signwriting col-signwriting-2">񅻱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00020.html">S1c6</a></td>
-<td class="signwriting">񄩁</td>
-<td class="signwriting">񄩑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00020.html">S1c6</a></td>
+<td class="signwriting col-signwriting-1">񄩁</td>
+<td class="signwriting col-signwriting-2">񄩑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00024.html">S1e0</a></td>
-<td class="signwriting">񅐁</td>
-<td class="signwriting">񅐑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00024.html">S1e0</a></td>
+<td class="signwriting col-signwriting-1">񅐁</td>
+<td class="signwriting col-signwriting-2">񅐑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00026.html">S1f2</a></td>
-<td class="signwriting">񅫁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00026.html">S1f2</a></td>
+<td class="signwriting col-signwriting-1">񅫁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00030.html">S198</a></td>
-<td class="signwriting">񃤑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00030.html">S198</a></td>
+<td class="signwriting col-signwriting-1">񃤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00048.html">S11d</a></td>
-<td class="signwriting">񀫡</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00048.html">S11d</a></td>
+<td class="signwriting col-signwriting-1">񀫡</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00087.html">S16e</a></td>
-<td class="signwriting">񂥑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00087.html">S16e</a></td>
+<td class="signwriting col-signwriting-1">񂥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00104.html">S199</a></td>
-<td class="signwriting">񃥱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00104.html">S199</a></td>
+<td class="signwriting col-signwriting-1">񃥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00118.html">S1a3</a></td>
-<td class="signwriting">񃴱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00118.html">S1a3</a></td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00147.html">S1d5</a></td>
-<td class="signwriting">񄿱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00147.html">S1d5</a></td>
+<td class="signwriting col-signwriting-1">񄿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00153.html">S1c1</a></td>
-<td class="signwriting">񄡱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00153.html">S1c1</a></td>
+<td class="signwriting col-signwriting-1">񄡱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00003.html
+++ b/docs/inventories/inv00003.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DGS (LQ_3)</title>
+  <title>Inventory: DGS (LQ_3)</title>
   
 <style>
 @font-face {
@@ -12,339 +12,561 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>DGS (LQ_3)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00003</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>DGS (LQ_3)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>German Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>LQ_3</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Longqian Ming</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: DGS (LQ_3)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00003</td>
+<td class="col-language-name">German Sign Language</td>
+<td class="col-contributor">Longqian Ming</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00004.html">S203</a></td>
-<td class="signwriting">񆄱</td>
-<td class="signwriting">񆅁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00004.html">S203</a></td>
+<td class="signwriting col-signwriting-1">񆄱</td>
+<td class="signwriting col-signwriting-2">񆅁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00061.html">S121</a></td>
-<td class="signwriting">񀱱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00061.html">S121</a></td>
+<td class="signwriting col-signwriting-1">񀱱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00085.html">S149</a></td>
-<td class="signwriting">񁭱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00085.html">S149</a></td>
+<td class="signwriting col-signwriting-1">񁭱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00004.html
+++ b/docs/inventories/inv00004.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>HKSL (LQ_4)</title>
+  <title>Inventory: HKSL (LQ_4)</title>
   
 <style>
 @font-face {
@@ -12,555 +12,777 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>HKSL (LQ_4)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00004</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>HKSL (LQ_4)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>LQ_4</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Longqian Ming</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: HKSL (LQ_4)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00004</td>
+<td class="col-language-name">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-contributor">Longqian Ming</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00004.html">S203</a></td>
-<td class="signwriting">񆄱</td>
-<td class="signwriting">񆅁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00004.html">S203</a></td>
+<td class="signwriting col-signwriting-1">񆄱</td>
+<td class="signwriting col-signwriting-2">񆅁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00007.html">S1fc</a></td>
-<td class="signwriting">񅺡</td>
-<td class="signwriting">񅺑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00007.html">S1fc</a></td>
+<td class="signwriting col-signwriting-1">񅺡</td>
+<td class="signwriting col-signwriting-2">񅺑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00008.html">S1fd</a></td>
-<td class="signwriting">񅼁</td>
-<td class="signwriting">񅻱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00008.html">S1fd</a></td>
+<td class="signwriting col-signwriting-1">񅼁</td>
+<td class="signwriting col-signwriting-2">񅻱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00020.html">S1c6</a></td>
-<td class="signwriting">񄩁</td>
-<td class="signwriting">񄩑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00020.html">S1c6</a></td>
+<td class="signwriting col-signwriting-1">񄩁</td>
+<td class="signwriting col-signwriting-2">񄩑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00024.html">S1e0</a></td>
-<td class="signwriting">񅐁</td>
-<td class="signwriting">񅐑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00024.html">S1e0</a></td>
+<td class="signwriting col-signwriting-1">񅐁</td>
+<td class="signwriting col-signwriting-2">񅐑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00027.html">S1f3</a></td>
-<td class="signwriting">񅬱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00027.html">S1f3</a></td>
+<td class="signwriting col-signwriting-1">񅬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00030.html">S198</a></td>
-<td class="signwriting">񃤑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00030.html">S198</a></td>
+<td class="signwriting col-signwriting-1">񃤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00061.html">S121</a></td>
-<td class="signwriting">񀱱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00061.html">S121</a></td>
+<td class="signwriting col-signwriting-1">񀱱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00090.html">S202</a></td>
-<td class="signwriting">񆃑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00090.html">S202</a></td>
+<td class="signwriting col-signwriting-1">񆃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00118.html">S1a3</a></td>
-<td class="signwriting">񃴱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00118.html">S1a3</a></td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00140.html">S18b</a></td>
-<td class="signwriting">񃐱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00140.html">S18b</a></td>
+<td class="signwriting col-signwriting-1">񃐱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00143.html">S1ba</a></td>
-<td class="signwriting">񄗁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00143.html">S1ba</a></td>
+<td class="signwriting col-signwriting-1">񄗁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00147.html">S1d5</a></td>
-<td class="signwriting">񄿱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00147.html">S1d5</a></td>
+<td class="signwriting col-signwriting-1">񄿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00153.html">S1c1</a></td>
-<td class="signwriting">񄡱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00153.html">S1c1</a></td>
+<td class="signwriting col-signwriting-1">񄡱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00005.html
+++ b/docs/inventories/inv00005.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>SSL, STS (LQ_5)</title>
+  <title>Inventory: SSL, STS (LQ_5)</title>
   
 <style>
 @font-face {
@@ -12,438 +12,660 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>SSL, STS (LQ_5)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00005</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>SSL, STS (LQ_5)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Swedish Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>LQ_5</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Longqian Ming</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: SSL, STS (LQ_5)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00005</td>
+<td class="col-language-name">Swedish Sign Language</td>
+<td class="col-contributor">Longqian Ming</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00004.html">S203</a></td>
-<td class="signwriting">񆄱</td>
-<td class="signwriting">񆅁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00004.html">S203</a></td>
+<td class="signwriting col-signwriting-1">񆄱</td>
+<td class="signwriting col-signwriting-2">񆅁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00011.html">S201</a></td>
-<td class="signwriting">񆁱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00011.html">S201</a></td>
+<td class="signwriting col-signwriting-1">񆁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00020.html">S1c6</a></td>
-<td class="signwriting">񄩁</td>
-<td class="signwriting">񄩑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00020.html">S1c6</a></td>
+<td class="signwriting col-signwriting-1">񄩁</td>
+<td class="signwriting col-signwriting-2">񄩑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00082.html">S14b</a></td>
-<td class="signwriting">񁰱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00082.html">S14b</a></td>
+<td class="signwriting col-signwriting-1">񁰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00105.html">S1e5</a></td>
-<td class="signwriting">񅗱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00105.html">S1e5</a></td>
+<td class="signwriting col-signwriting-1">񅗱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00159.html">S1d8</a></td>
-<td class="signwriting">񅄑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00159.html">S1d8</a></td>
+<td class="signwriting col-signwriting-1">񅄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00006.html
+++ b/docs/inventories/inv00006.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>BSL (LQ_6)</title>
+  <title>Inventory: BSL (LQ_6)</title>
   
 <style>
 @font-face {
@@ -12,582 +12,804 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>BSL (LQ_6)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00006</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>BSL (LQ_6)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>British Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>LQ_6</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Longqian Ming</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: BSL (LQ_6)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00006</td>
+<td class="col-language-name">British Sign Language</td>
+<td class="col-contributor">Longqian Ming</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00004.html">S203</a></td>
-<td class="signwriting">񆄱</td>
-<td class="signwriting">񆅁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00004.html">S203</a></td>
+<td class="signwriting col-signwriting-1">񆄱</td>
+<td class="signwriting col-signwriting-2">񆅁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00020.html">S1c6</a></td>
-<td class="signwriting">񄩁</td>
-<td class="signwriting">񄩑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00020.html">S1c6</a></td>
+<td class="signwriting col-signwriting-1">񄩁</td>
+<td class="signwriting col-signwriting-2">񄩑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00055.html">S1b0</a></td>
-<td class="signwriting">񄈑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00055.html">S1b0</a></td>
+<td class="signwriting col-signwriting-1">񄈑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_nonspread</td>
-<td>extended</td>
-<td><a href="../segments/seg00066.html">S18e</a></td>
-<td class="signwriting">񃕑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00066.html">S18e</a></td>
+<td class="signwriting col-signwriting-1">񃕑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>extended</td>
-<td><a href="../segments/seg00074.html">S1c4</a></td>
-<td class="signwriting">񄦑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00074.html">S1c4</a></td>
+<td class="signwriting col-signwriting-1">񄦑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00087.html">S16e</a></td>
-<td class="signwriting">񂥑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00087.html">S16e</a></td>
+<td class="signwriting col-signwriting-1">񂥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00088.html">S170</a></td>
-<td class="signwriting">񂨑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00088.html">S170</a></td>
+<td class="signwriting col-signwriting-1">񂨑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00118.html">S1a3</a></td>
-<td class="signwriting">񃴱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00118.html">S1a3</a></td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00127.html">S173</a></td>
-<td class="signwriting">񂬱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00127.html">S173</a></td>
+<td class="signwriting col-signwriting-1">񂬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00141.html">S1a4</a></td>
-<td class="signwriting">񃶁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00141.html">S1a4</a></td>
+<td class="signwriting col-signwriting-1">񃶁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00007.html
+++ b/docs/inventories/inv00007.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Auslan (LQ_7)</title>
+  <title>Inventory: Auslan (LQ_7)</title>
   
 <style>
 @font-face {
@@ -12,420 +12,642 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Auslan (LQ_7)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00007</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>Auslan (LQ_7)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Auslan (Australian Sign Language)</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>LQ_7</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Longqian Ming</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: Auslan (LQ_7)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00007</td>
+<td class="col-language-name">Auslan (Australian Sign Language)</td>
+<td class="col-contributor">Longqian Ming</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00004.html">S203</a></td>
-<td class="signwriting">񆄱</td>
-<td class="signwriting">񆅁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00004.html">S203</a></td>
+<td class="signwriting col-signwriting-1">񆄱</td>
+<td class="signwriting col-signwriting-2">񆅁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00014.html">S103</a></td>
-<td class="signwriting">񀄱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00014.html">S103</a></td>
+<td class="signwriting col-signwriting-1">񀄱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00106.html">S1e7</a></td>
-<td class="signwriting">񅚱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00106.html">S1e7</a></td>
+<td class="signwriting col-signwriting-1">񅚱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00008.html
+++ b/docs/inventories/inv00008.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>NZSL (LQ_8)</title>
+  <title>Inventory: NZSL (LQ_8)</title>
   
 <style>
 @font-face {
@@ -12,591 +12,813 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>NZSL (LQ_8)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00008</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>NZSL (LQ_8)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>New Zealand Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>LQ_8</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Longqian Ming</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: NZSL (LQ_8)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00008</td>
+<td class="col-language-name">New Zealand Sign Language</td>
+<td class="col-contributor">Longqian Ming</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00004.html">S203</a></td>
-<td class="signwriting">񆄱</td>
-<td class="signwriting">񆅁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00004.html">S203</a></td>
+<td class="signwriting col-signwriting-1">񆄱</td>
+<td class="signwriting col-signwriting-2">񆅁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00011.html">S201</a></td>
-<td class="signwriting">񆁱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00011.html">S201</a></td>
+<td class="signwriting col-signwriting-1">񆁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00020.html">S1c6</a></td>
-<td class="signwriting">񄩁</td>
-<td class="signwriting">񄩑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00020.html">S1c6</a></td>
+<td class="signwriting col-signwriting-1">񄩁</td>
+<td class="signwriting col-signwriting-2">񄩑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00059.html">S123</a></td>
-<td class="signwriting">񀴱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00059.html">S123</a></td>
+<td class="signwriting col-signwriting-1">񀴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00061.html">S121</a></td>
-<td class="signwriting">񀱱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00061.html">S121</a></td>
+<td class="signwriting col-signwriting-1">񀱱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00090.html">S202</a></td>
-<td class="signwriting">񆃑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00090.html">S202</a></td>
+<td class="signwriting col-signwriting-1">񆃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00095.html">S158</a></td>
-<td class="signwriting">񂄑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00095.html">S158</a></td>
+<td class="signwriting col-signwriting-1">񂄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00105.html">S1e5</a></td>
-<td class="signwriting">񅗱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00105.html">S1e5</a></td>
+<td class="signwriting col-signwriting-1">񅗱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00110.html">S1e4</a></td>
-<td class="signwriting">񅖑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00110.html">S1e4</a></td>
+<td class="signwriting col-signwriting-1">񅖑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00124.html">S127</a></td>
-<td class="signwriting">񀺱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00124.html">S127</a></td>
+<td class="signwriting col-signwriting-1">񀺱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00140.html">S18b</a></td>
-<td class="signwriting">񃐱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00140.html">S18b</a></td>
+<td class="signwriting col-signwriting-1">񃐱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00009.html
+++ b/docs/inventories/inv00009.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>TSL (LQ_9)</title>
+  <title>Inventory: TSL (LQ_9)</title>
   
 <style>
 @font-face {
@@ -12,582 +12,804 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>TSL (LQ_9)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00009</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>TSL (LQ_9)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Taiwan Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>LQ_9</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Longqian Ming</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: TSL (LQ_9)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00009</td>
+<td class="col-language-name">Taiwan Sign Language</td>
+<td class="col-contributor">Longqian Ming</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00004.html">S203</a></td>
-<td class="signwriting">񆄱</td>
-<td class="signwriting">񆅁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00004.html">S203</a></td>
+<td class="signwriting col-signwriting-1">񆄱</td>
+<td class="signwriting col-signwriting-2">񆅁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00008.html">S1fd</a></td>
-<td class="signwriting">񅼁</td>
-<td class="signwriting">񅻱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00008.html">S1fd</a></td>
+<td class="signwriting col-signwriting-1">񅼁</td>
+<td class="signwriting col-signwriting-2">񅻱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00014.html">S103</a></td>
-<td class="signwriting">񀄱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00014.html">S103</a></td>
+<td class="signwriting col-signwriting-1">񀄱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00019.html">S1ae</a></td>
-<td class="signwriting">񄅑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00019.html">S1ae</a></td>
+<td class="signwriting col-signwriting-1">񄅑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00020.html">S1c6</a></td>
-<td class="signwriting">񄩁</td>
-<td class="signwriting">񄩑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00020.html">S1c6</a></td>
+<td class="signwriting col-signwriting-1">񄩁</td>
+<td class="signwriting col-signwriting-2">񄩑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00024.html">S1e0</a></td>
-<td class="signwriting">񅐁</td>
-<td class="signwriting">񅐑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00024.html">S1e0</a></td>
+<td class="signwriting col-signwriting-1">񅐁</td>
+<td class="signwriting col-signwriting-2">񅐑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00026.html">S1f2</a></td>
-<td class="signwriting">񅫁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00026.html">S1f2</a></td>
+<td class="signwriting col-signwriting-1">񅫁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00030.html">S198</a></td>
-<td class="signwriting">񃤑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00030.html">S198</a></td>
+<td class="signwriting col-signwriting-1">񃤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00041.html">S13e</a></td>
-<td class="signwriting">񁝑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00041.html">S13e</a></td>
+<td class="signwriting col-signwriting-1">񁝑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00063.html">S126</a></td>
-<td class="signwriting">񀹑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00063.html">S126</a></td>
+<td class="signwriting col-signwriting-1">񀹑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00057.html">S1cb</a></td>
-<td class="signwriting">񄰱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00057.html">S1cb</a></td>
+<td class="signwriting col-signwriting-1">񄰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00058.html">S112</a></td>
-<td class="signwriting">񀛑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00058.html">S112</a></td>
+<td class="signwriting col-signwriting-1">񀛑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00065.html">S142</a></td>
-<td class="signwriting">񁣑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00065.html">S142</a></td>
+<td class="signwriting col-signwriting-1">񁣑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_nonspread</td>
-<td>extended</td>
-<td><a href="../segments/seg00066.html">S18e</a></td>
-<td class="signwriting">񃕑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00066.html">S18e</a></td>
+<td class="signwriting col-signwriting-1">񃕑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>bent</td>
-<td><a href="../segments/seg00076.html">S190</a></td>
-<td class="signwriting">񃘑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">bent</td>
+<td class="col-fsw"><a href="../segments/seg00076.html">S190</a></td>
+<td class="signwriting col-signwriting-1">񃘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00104.html">S199</a></td>
-<td class="signwriting">񃥱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00104.html">S199</a></td>
+<td class="signwriting col-signwriting-1">񃥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00118.html">S1a3</a></td>
-<td class="signwriting">񃴱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00118.html">S1a3</a></td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00120.html">S1b3</a></td>
-<td class="signwriting">񄌱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00120.html">S1b3</a></td>
+<td class="signwriting col-signwriting-1">񄌱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00140.html">S18b</a></td>
-<td class="signwriting">񃐱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00140.html">S18b</a></td>
+<td class="signwriting col-signwriting-1">񃐱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00161.html">S196</a></td>
-<td class="signwriting">񃡑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00161.html">S196</a></td>
+<td class="signwriting col-signwriting-1">񃡑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00010.html
+++ b/docs/inventories/inv00010.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>KSL (LQ_10)</title>
+  <title>Inventory: KSL (LQ_10)</title>
   
 <style>
 @font-face {
@@ -12,618 +12,840 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>KSL (LQ_10)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00010</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>KSL (LQ_10)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Korean Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>LQ_10</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Longqian Ming</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: KSL (LQ_10)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00010</td>
+<td class="col-language-name">Korean Sign Language</td>
+<td class="col-contributor">Longqian Ming</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00004.html">S203</a></td>
-<td class="signwriting">񆄱</td>
-<td class="signwriting">񆅁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00004.html">S203</a></td>
+<td class="signwriting col-signwriting-1">񆄱</td>
+<td class="signwriting col-signwriting-2">񆅁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00009.html">S1ff</a></td>
-<td class="signwriting">񅾱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00009.html">S1ff</a></td>
+<td class="signwriting col-signwriting-1">񅾱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00010.html">S200</a></td>
-<td class="signwriting">񆀑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00010.html">S200</a></td>
+<td class="signwriting col-signwriting-1">񆀑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00023.html">S1df</a></td>
-<td class="signwriting">񅎱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00023.html">S1df</a></td>
+<td class="signwriting col-signwriting-1">񅎱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00030.html">S198</a></td>
-<td class="signwriting">񃤑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00030.html">S198</a></td>
+<td class="signwriting col-signwriting-1">񃤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00032.html">S1e2</a></td>
-<td class="signwriting">񅓁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00032.html">S1e2</a></td>
+<td class="signwriting col-signwriting-1">񅓁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00038.html">S1b5</a></td>
-<td class="signwriting">񄏱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00038.html">S1b5</a></td>
+<td class="signwriting col-signwriting-1">񄏱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00046.html">S116</a></td>
-<td class="signwriting">񀡑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00046.html">S116</a></td>
+<td class="signwriting col-signwriting-1">񀡑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00056.html">S1b4</a></td>
-<td class="signwriting">񄎑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00056.html">S1b4</a></td>
+<td class="signwriting col-signwriting-1">񄎑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00061.html">S121</a></td>
-<td class="signwriting">񀱱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00061.html">S121</a></td>
+<td class="signwriting col-signwriting-1">񀱱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00063.html">S126</a></td>
-<td class="signwriting">񀹑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00063.html">S126</a></td>
+<td class="signwriting col-signwriting-1">񀹑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_nonspread</td>
-<td>extended</td>
-<td><a href="../segments/seg00066.html">S18e</a></td>
-<td class="signwriting">񃕑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00066.html">S18e</a></td>
+<td class="signwriting col-signwriting-1">񃕑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00141.html">S1a4</a></td>
-<td class="signwriting">񃶁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00141.html">S1a4</a></td>
+<td class="signwriting col-signwriting-1">񃶁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>bent</td>
-<td><a href="../segments/seg00076.html">S190</a></td>
-<td class="signwriting">񃘑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">bent</td>
+<td class="col-fsw"><a href="../segments/seg00076.html">S190</a></td>
+<td class="signwriting col-signwriting-1">񃘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00088.html">S170</a></td>
-<td class="signwriting">񂨑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00088.html">S170</a></td>
+<td class="signwriting col-signwriting-1">񂨑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00091.html">S1d7</a></td>
-<td class="signwriting">񅂱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00091.html">S1d7</a></td>
+<td class="signwriting col-signwriting-1">񅂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00096.html">S159</a></td>
-<td class="signwriting">񂅱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00096.html">S159</a></td>
+<td class="signwriting col-signwriting-1">񂅱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00105.html">S1e5</a></td>
-<td class="signwriting">񅗱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00105.html">S1e5</a></td>
+<td class="signwriting col-signwriting-1">񅗱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00109.html">S19f</a></td>
-<td class="signwriting">񃮱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00109.html">S19f</a></td>
+<td class="signwriting col-signwriting-1">񃮱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00119.html">S1b2</a></td>
-<td class="signwriting">񄋑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00119.html">S1b2</a></td>
+<td class="signwriting col-signwriting-1">񄋑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00123.html">S12b</a></td>
-<td class="signwriting">񁀱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00123.html">S12b</a></td>
+<td class="signwriting col-signwriting-1">񁀱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00140.html">S18b</a></td>
-<td class="signwriting">񃐱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00140.html">S18b</a></td>
+<td class="signwriting col-signwriting-1">񃐱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00148.html">S1d6</a></td>
-<td class="signwriting">񅁑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00148.html">S1d6</a></td>
+<td class="signwriting col-signwriting-1">񅁑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00153.html">S1c1</a></td>
-<td class="signwriting">񄡱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00153.html">S1c1</a></td>
+<td class="signwriting col-signwriting-1">񄡱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00011.html
+++ b/docs/inventories/inv00011.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DSL, DTS (LQ_11)</title>
+  <title>Inventory: DSL, DTS (LQ_11)</title>
   
 <style>
 @font-face {
@@ -12,618 +12,840 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>DSL, DTS (LQ_11)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00011</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>DSL, DTS (LQ_11)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Danish Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>LQ_11</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Longqian Ming</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: DSL, DTS (LQ_11)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00011</td>
+<td class="col-language-name">Danish Sign Language</td>
+<td class="col-contributor">Longqian Ming</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00004.html">S203</a></td>
-<td class="signwriting">񆄱</td>
-<td class="signwriting">񆅁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00004.html">S203</a></td>
+<td class="signwriting col-signwriting-1">񆄱</td>
+<td class="signwriting col-signwriting-2">񆅁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00020.html">S1c6</a></td>
-<td class="signwriting">񄩁</td>
-<td class="signwriting">񄩑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00020.html">S1c6</a></td>
+<td class="signwriting col-signwriting-1">񄩁</td>
+<td class="signwriting col-signwriting-2">񄩑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00026.html">S1f2</a></td>
-<td class="signwriting">񅫁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00026.html">S1f2</a></td>
+<td class="signwriting col-signwriting-1">񅫁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00040.html">S132</a></td>
-<td class="signwriting">񁋑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00040.html">S132</a></td>
+<td class="signwriting col-signwriting-1">񁋑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00052.html">S125</a></td>
-<td class="signwriting">񀷱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00052.html">S125</a></td>
+<td class="signwriting col-signwriting-1">񀷱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00062.html">S122</a></td>
-<td class="signwriting">񀳑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00062.html">S122</a></td>
+<td class="signwriting col-signwriting-1">񀳑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00085.html">S149</a></td>
-<td class="signwriting">񁭱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00085.html">S149</a></td>
+<td class="signwriting col-signwriting-1">񁭱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00086.html">S168</a></td>
-<td class="signwriting">񂜑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00086.html">S168</a></td>
+<td class="signwriting col-signwriting-1">񂜑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00090.html">S202</a></td>
-<td class="signwriting">񆃑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00090.html">S202</a></td>
+<td class="signwriting col-signwriting-1">񆃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00123.html">S12b</a></td>
-<td class="signwriting">񁀱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00123.html">S12b</a></td>
+<td class="signwriting col-signwriting-1">񁀱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00141.html">S1a4</a></td>
-<td class="signwriting">񃶁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00141.html">S1a4</a></td>
+<td class="signwriting col-signwriting-1">񃶁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00143.html">S1ba</a></td>
-<td class="signwriting">񄗁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00143.html">S1ba</a></td>
+<td class="signwriting col-signwriting-1">񄗁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00012.html
+++ b/docs/inventories/inv00012.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>NGT, SLN (LQ_12)</title>
+  <title>Inventory: NGT, SLN (LQ_12)</title>
   
 <style>
 @font-face {
@@ -12,726 +12,948 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>NGT, SLN (LQ_12)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00012</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>NGT, SLN (LQ_12)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>LQ_12</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Longqian Ming</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: NGT, SLN (LQ_12)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00012</td>
+<td class="col-language-name">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-contributor">Longqian Ming</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00004.html">S203</a></td>
-<td class="signwriting">񆄱</td>
-<td class="signwriting">񆅁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00011.html">S201</a></td>
-<td class="signwriting">񆁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00015.html">S108</a></td>
-<td class="signwriting">񀌑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00017.html">S193</a></td>
-<td class="signwriting">񃜱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00020.html">S1c6</a></td>
-<td class="signwriting">񄩁</td>
-<td class="signwriting">񄩑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00023.html">S1df</a></td>
-<td class="signwriting">񅎱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00026.html">S1f2</a></td>
-<td class="signwriting">񅫁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00052.html">S125</a></td>
-<td class="signwriting">񀷱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00062.html">S122</a></td>
-<td class="signwriting">񀳑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>extended</td>
-<td><a href="../segments/seg00071.html">S18f</a></td>
-<td class="signwriting">񃖱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00087.html">S16e</a></td>
-<td class="signwriting">񂥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00088.html">S170</a></td>
-<td class="signwriting">񂨑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00095.html">S158</a></td>
-<td class="signwriting">񂄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00096.html">S159</a></td>
-<td class="signwriting">񂅱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00102.html">S1a7</a></td>
-<td class="signwriting">񃺱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00122.html">S12a</a></td>
-<td class="signwriting">񀿑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00123.html">S12b</a></td>
-<td class="signwriting">񁀱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00140.html">S18b</a></td>
-<td class="signwriting">񃐱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00142.html">S1a5</a></td>
-<td class="signwriting">񃷱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00157.html">S1d3</a></td>
-<td class="signwriting">񄼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00160.html">S105</a></td>
-<td class="signwriting">񀇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00004.html">S203</a></td>
+<td class="signwriting col-signwriting-1">񆄱</td>
+<td class="signwriting col-signwriting-2">񆅁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00011.html">S201</a></td>
+<td class="signwriting col-signwriting-1">񆁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00015.html">S108</a></td>
+<td class="signwriting col-signwriting-1">񀌑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00017.html">S193</a></td>
+<td class="signwriting col-signwriting-1">񃜱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00020.html">S1c6</a></td>
+<td class="signwriting col-signwriting-1">񄩁</td>
+<td class="signwriting col-signwriting-2">񄩑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00023.html">S1df</a></td>
+<td class="signwriting col-signwriting-1">񅎱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00026.html">S1f2</a></td>
+<td class="signwriting col-signwriting-1">񅫁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00052.html">S125</a></td>
+<td class="signwriting col-signwriting-1">񀷱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00062.html">S122</a></td>
+<td class="signwriting col-signwriting-1">񀳑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00071.html">S18f</a></td>
+<td class="signwriting col-signwriting-1">񃖱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00087.html">S16e</a></td>
+<td class="signwriting col-signwriting-1">񂥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00088.html">S170</a></td>
+<td class="signwriting col-signwriting-1">񂨑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00095.html">S158</a></td>
+<td class="signwriting col-signwriting-1">񂄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00096.html">S159</a></td>
+<td class="signwriting col-signwriting-1">񂅱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00102.html">S1a7</a></td>
+<td class="signwriting col-signwriting-1">񃺱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00122.html">S12a</a></td>
+<td class="signwriting col-signwriting-1">񀿑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00123.html">S12b</a></td>
+<td class="signwriting col-signwriting-1">񁀱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00140.html">S18b</a></td>
+<td class="signwriting col-signwriting-1">񃐱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00142.html">S1a5</a></td>
+<td class="signwriting col-signwriting-1">񃷱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00157.html">S1d3</a></td>
+<td class="signwriting col-signwriting-1">񄼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00160.html">S105</a></td>
+<td class="signwriting col-signwriting-1">񀇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00013.html
+++ b/docs/inventories/inv00013.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>AFSL (SP_106)</title>
+  <title>Inventory: AFSL (SP_106)</title>
   
 <style>
 @font-face {
@@ -12,159 +12,381 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>AFSL (SP_106)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00013</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>AFSL (SP_106)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Afghan Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_106</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: AFSL (SP_106)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00013</td>
+<td class="col-language-name">Afghan Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00014.html
+++ b/docs/inventories/inv00014.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>AlbSL (SP_82)</title>
+  <title>Inventory: AlbSL (SP_82)</title>
   
 <style>
 @font-face {
@@ -12,411 +12,633 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>AlbSL (SP_82)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00014</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>AlbSL (SP_82)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Albanian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_82</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: AlbSL (SP_82)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00014</td>
+<td class="col-language-name">Albanian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00164.html">S14d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00164.html">S14d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00167.html">S1cd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00167.html">S1cd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00168.html">S1dd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00168.html">S1dd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00015.html
+++ b/docs/inventories/inv00015.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LSA (SP_41)</title>
+  <title>Inventory: LSA (SP_41)</title>
   
 <style>
 @font-face {
@@ -12,861 +12,1083 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LSA (SP_41)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00015</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LSA (SP_41)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Argentine Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_41</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LSA (SP_41)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00015</td>
+<td class="col-language-name">Argentine Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00256.html">S1bc</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00110.html">S1e4</a></td>
-<td class="signwriting">񅖑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00216.html">S167</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00261.html">S1c2</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00222.html">S174</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00048.html">S11d</a></td>
-<td class="signwriting">񀫡</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00095.html">S158</a></td>
-<td class="signwriting">񂄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00026.html">S1f2</a></td>
-<td class="signwriting">񅫁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00030.html">S198</a></td>
-<td class="signwriting">񃤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00118.html">S1a3</a></td>
-<td class="signwriting">񃴱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00190.html">S134</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00085.html">S149</a></td>
-<td class="signwriting">񁭱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00243.html">S1a1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00181.html">S11f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00189.html">S133</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00173.html">S10d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00215.html">S166</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00106.html">S1e7</a></td>
-<td class="signwriting">񅚱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>extended</td>
-<td><a href="../segments/seg00074.html">S1c4</a></td>
-<td class="signwriting">񄦑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00267.html">S1cf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00193.html">S137</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00198.html">S13c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00014.html">S103</a></td>
-<td class="signwriting">񀄱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00256.html">S1bc</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00110.html">S1e4</a></td>
+<td class="signwriting col-signwriting-1">񅖑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00216.html">S167</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00261.html">S1c2</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00222.html">S174</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00048.html">S11d</a></td>
+<td class="signwriting col-signwriting-1">񀫡</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00095.html">S158</a></td>
+<td class="signwriting col-signwriting-1">񂄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00026.html">S1f2</a></td>
+<td class="signwriting col-signwriting-1">񅫁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00030.html">S198</a></td>
+<td class="signwriting col-signwriting-1">񃤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00118.html">S1a3</a></td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00190.html">S134</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00085.html">S149</a></td>
+<td class="signwriting col-signwriting-1">񁭱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00243.html">S1a1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00181.html">S11f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00189.html">S133</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00173.html">S10d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00215.html">S166</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00106.html">S1e7</a></td>
+<td class="signwriting col-signwriting-1">񅚱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00074.html">S1c4</a></td>
+<td class="signwriting col-signwriting-1">񄦑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00267.html">S1cf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00193.html">S137</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00198.html">S13c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00014.html">S103</a></td>
+<td class="signwriting col-signwriting-1">񀄱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00016.html
+++ b/docs/inventories/inv00016.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ÖGS (SP_29)</title>
+  <title>Inventory: ÖGS (SP_29)</title>
   
 <style>
 @font-face {
@@ -12,105 +12,327 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>ÖGS (SP_29)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00016</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>ÖGS (SP_29)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Austrian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_29</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: ÖGS (SP_29)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00016</td>
+<td class="col-language-name">Austrian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00017.html
+++ b/docs/inventories/inv00017.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Auslan (SP_42)</title>
+  <title>Inventory: Auslan (SP_42)</title>
   
 <style>
 @font-face {
@@ -12,582 +12,804 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Auslan (SP_42)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00017</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>Auslan (SP_42)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Auslan (Australian Sign Language)</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_42</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: Auslan (SP_42)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00017</td>
+<td class="col-language-name">Auslan (Australian Sign Language)</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00164.html">S14d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00164.html">S14d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00202.html">S14f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00202.html">S14f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00230.html">S183</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00230.html">S183</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00059.html">S123</a></td>
-<td class="signwriting">񀴱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00059.html">S123</a></td>
+<td class="signwriting col-signwriting-1">񀴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00222.html">S174</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00222.html">S174</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00176.html">S113</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00176.html">S113</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00214.html">S165</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00214.html">S165</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00046.html">S116</a></td>
-<td class="signwriting">񀡑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00046.html">S116</a></td>
+<td class="signwriting col-signwriting-1">񀡑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00058.html">S112</a></td>
-<td class="signwriting">񀛑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00058.html">S112</a></td>
+<td class="signwriting col-signwriting-1">񀛑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00257.html">S1bd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00257.html">S1bd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00185.html">S12e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00185.html">S12e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00190.html">S134</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00190.html">S134</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00225.html">S179</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00225.html">S179</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00253.html">S1b7</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00253.html">S1b7</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>extended</td>
-<td><a href="../segments/seg00073.html">S1ab</a></td>
-<td class="signwriting">񄀱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00073.html">S1ab</a></td>
+<td class="signwriting col-signwriting-1">񄀱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00183.html">S124</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00183.html">S124</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00161.html">S196</a></td>
-<td class="signwriting">񃡑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00161.html">S196</a></td>
+<td class="signwriting col-signwriting-1">񃡑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00206.html">S15b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00206.html">S15b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00082.html">S14b</a></td>
-<td class="signwriting">񁰱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00082.html">S14b</a></td>
+<td class="signwriting col-signwriting-1">񁰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00199.html">S141</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00199.html">S141</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00141.html">S1a4</a></td>
-<td class="signwriting">񃶁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00141.html">S1a4</a></td>
+<td class="signwriting col-signwriting-1">񃶁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00171.html">S107</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00171.html">S107</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00087.html">S16e</a></td>
-<td class="signwriting">񂥑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00087.html">S16e</a></td>
+<td class="signwriting col-signwriting-1">񂥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00018.html
+++ b/docs/inventories/inv00018.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LSFB (SP_43)</title>
+  <title>Inventory: LSFB (SP_43)</title>
   
 <style>
 @font-face {
@@ -12,1014 +12,1236 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LSFB (SP_43)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00018</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LSFB (SP_43)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_43</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LSFB (SP_43)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00018</td>
+<td class="col-language-name">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00227.html">S17b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00040.html">S132</a></td>
-<td class="signwriting">񁋑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00082.html">S14b</a></td>
-<td class="signwriting">񁰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00061.html">S121</a></td>
-<td class="signwriting">񀱱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00183.html">S124</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00085.html">S149</a></td>
-<td class="signwriting">񁭱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>bent</td>
-<td><a href="../segments/seg00076.html">S190</a></td>
-<td class="signwriting">񃘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00153.html">S1c1</a></td>
-<td class="signwriting">񄡱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00127.html">S173</a></td>
-<td class="signwriting">񂬱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00123.html">S12b</a></td>
-<td class="signwriting">񁀱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00190.html">S134</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00172.html">S109</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00176.html">S113</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00157.html">S1d3</a></td>
-<td class="signwriting">񄼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00124.html">S127</a></td>
-<td class="signwriting">񀺱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00140.html">S18b</a></td>
-<td class="signwriting">񃐱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00024.html">S1e0</a></td>
-<td class="signwriting">񅐁</td>
-<td class="signwriting">񅐑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00065.html">S142</a></td>
-<td class="signwriting">񁣑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00224.html">S178</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00109.html">S19f</a></td>
-<td class="signwriting">񃮱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00243.html">S1a1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00260.html">S1c0</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00020.html">S1c6</a></td>
-<td class="signwriting">񄩁</td>
-<td class="signwriting">񄩑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00239.html">S197</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_nonspread</td>
-<td>extended</td>
-<td><a href="../segments/seg00066.html">S18e</a></td>
-<td class="signwriting">񃕑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00189.html">S133</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00258.html">S1be</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00159.html">S1d8</a></td>
-<td class="signwriting">񅄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00216.html">S167</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00194.html">S138</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00247.html">S1a9</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>extended</td>
-<td><a href="../segments/seg00074.html">S1c4</a></td>
-<td class="signwriting">񄦑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00169.html">S102</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00222.html">S174</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00267.html">S1cf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00198.html">S13c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00227.html">S17b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00040.html">S132</a></td>
+<td class="signwriting col-signwriting-1">񁋑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00082.html">S14b</a></td>
+<td class="signwriting col-signwriting-1">񁰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00061.html">S121</a></td>
+<td class="signwriting col-signwriting-1">񀱱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00183.html">S124</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00085.html">S149</a></td>
+<td class="signwriting col-signwriting-1">񁭱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">bent</td>
+<td class="col-fsw"><a href="../segments/seg00076.html">S190</a></td>
+<td class="signwriting col-signwriting-1">񃘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00153.html">S1c1</a></td>
+<td class="signwriting col-signwriting-1">񄡱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00127.html">S173</a></td>
+<td class="signwriting col-signwriting-1">񂬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00123.html">S12b</a></td>
+<td class="signwriting col-signwriting-1">񁀱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00190.html">S134</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00172.html">S109</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00176.html">S113</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00157.html">S1d3</a></td>
+<td class="signwriting col-signwriting-1">񄼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00124.html">S127</a></td>
+<td class="signwriting col-signwriting-1">񀺱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00140.html">S18b</a></td>
+<td class="signwriting col-signwriting-1">񃐱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00024.html">S1e0</a></td>
+<td class="signwriting col-signwriting-1">񅐁</td>
+<td class="signwriting col-signwriting-2">񅐑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00065.html">S142</a></td>
+<td class="signwriting col-signwriting-1">񁣑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00224.html">S178</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00109.html">S19f</a></td>
+<td class="signwriting col-signwriting-1">񃮱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00243.html">S1a1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00260.html">S1c0</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00020.html">S1c6</a></td>
+<td class="signwriting col-signwriting-1">񄩁</td>
+<td class="signwriting col-signwriting-2">񄩑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00239.html">S197</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00066.html">S18e</a></td>
+<td class="signwriting col-signwriting-1">񃕑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00189.html">S133</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00258.html">S1be</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00159.html">S1d8</a></td>
+<td class="signwriting col-signwriting-1">񅄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00216.html">S167</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00194.html">S138</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00247.html">S1a9</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00074.html">S1c4</a></td>
+<td class="signwriting col-signwriting-1">񄦑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00169.html">S102</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00222.html">S174</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00267.html">S1cf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00198.html">S13c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00019.html
+++ b/docs/inventories/inv00019.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>VGT (SP_44)</title>
+  <title>Inventory: VGT (SP_44)</title>
   
 <style>
 @font-face {
@@ -12,1302 +12,1524 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>VGT (SP_44)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00019</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>VGT (SP_44)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_44</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: VGT (SP_44)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00019</td>
+<td class="col-language-name">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00065.html">S142</a></td>
-<td class="signwriting">񁣑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00127.html">S173</a></td>
-<td class="signwriting">񂬱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00227.html">S17b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00228.html">S17f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00267.html">S1cf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00223.html">S175</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00216.html">S167</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00224.html">S178</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00082.html">S14b</a></td>
-<td class="signwriting">񁰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00259.html">S1bf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00167.html">S1cd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00032.html">S1e2</a></td>
-<td class="signwriting">񅓁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00140.html">S18b</a></td>
-<td class="signwriting">񃐱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00157.html">S1d3</a></td>
-<td class="signwriting">񄼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00153.html">S1c1</a></td>
-<td class="signwriting">񄡱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00087.html">S16e</a></td>
-<td class="signwriting">񂥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00194.html">S138</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00026.html">S1f2</a></td>
-<td class="signwriting">񅫁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00123.html">S12b</a></td>
-<td class="signwriting">񁀱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00226.html">S17a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00106.html">S1e7</a></td>
-<td class="signwriting">񅚱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00062.html">S122</a></td>
-<td class="signwriting">񀳑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00180.html">S11c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00122.html">S12a</a></td>
-<td class="signwriting">񀿑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00234.html">S189</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00225.html">S179</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00176.html">S113</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00272.html">S1e8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00222.html">S174</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00040.html">S132</a></td>
-<td class="signwriting">񁋑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00094.html">S146</a></td>
-<td class="signwriting">񁩑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00190.html">S134</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00095.html">S158</a></td>
-<td class="signwriting">񂄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00102.html">S1a7</a></td>
-<td class="signwriting">񃺱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00174.html">S10f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00221.html">S172</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00237.html">S194</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00118.html">S1a3</a></td>
-<td class="signwriting">񃴱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00245.html">S1a6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00058.html">S112</a></td>
-<td class="signwriting">񀛑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00217.html">S169</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00020.html">S1c6</a></td>
-<td class="signwriting">񄩁</td>
-<td class="signwriting">񄩑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00181.html">S11f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00203.html">S151</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00061.html">S121</a></td>
-<td class="signwriting">񀱱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00246.html">S1a8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00241.html">S19d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00023.html">S1df</a></td>
-<td class="signwriting">񅎱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00085.html">S149</a></td>
-<td class="signwriting">񁭱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00242.html">S19e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00182.html">S120</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00088.html">S170</a></td>
-<td class="signwriting">񂨑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00271.html">S1e6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00209.html">S15f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00065.html">S142</a></td>
+<td class="signwriting col-signwriting-1">񁣑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00127.html">S173</a></td>
+<td class="signwriting col-signwriting-1">񂬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00227.html">S17b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00228.html">S17f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00267.html">S1cf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00223.html">S175</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00216.html">S167</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00224.html">S178</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00082.html">S14b</a></td>
+<td class="signwriting col-signwriting-1">񁰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00259.html">S1bf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00167.html">S1cd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00032.html">S1e2</a></td>
+<td class="signwriting col-signwriting-1">񅓁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00140.html">S18b</a></td>
+<td class="signwriting col-signwriting-1">񃐱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00157.html">S1d3</a></td>
+<td class="signwriting col-signwriting-1">񄼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00153.html">S1c1</a></td>
+<td class="signwriting col-signwriting-1">񄡱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00087.html">S16e</a></td>
+<td class="signwriting col-signwriting-1">񂥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00194.html">S138</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00026.html">S1f2</a></td>
+<td class="signwriting col-signwriting-1">񅫁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00123.html">S12b</a></td>
+<td class="signwriting col-signwriting-1">񁀱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00226.html">S17a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00106.html">S1e7</a></td>
+<td class="signwriting col-signwriting-1">񅚱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00062.html">S122</a></td>
+<td class="signwriting col-signwriting-1">񀳑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00180.html">S11c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00122.html">S12a</a></td>
+<td class="signwriting col-signwriting-1">񀿑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00234.html">S189</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00225.html">S179</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00176.html">S113</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00272.html">S1e8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00222.html">S174</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00040.html">S132</a></td>
+<td class="signwriting col-signwriting-1">񁋑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00094.html">S146</a></td>
+<td class="signwriting col-signwriting-1">񁩑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00190.html">S134</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00095.html">S158</a></td>
+<td class="signwriting col-signwriting-1">񂄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00102.html">S1a7</a></td>
+<td class="signwriting col-signwriting-1">񃺱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00174.html">S10f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00221.html">S172</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00237.html">S194</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00118.html">S1a3</a></td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00245.html">S1a6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00058.html">S112</a></td>
+<td class="signwriting col-signwriting-1">񀛑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00217.html">S169</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00020.html">S1c6</a></td>
+<td class="signwriting col-signwriting-1">񄩁</td>
+<td class="signwriting col-signwriting-2">񄩑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00181.html">S11f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00203.html">S151</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00061.html">S121</a></td>
+<td class="signwriting col-signwriting-1">񀱱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00246.html">S1a8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00241.html">S19d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00023.html">S1df</a></td>
+<td class="signwriting col-signwriting-1">񅎱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00085.html">S149</a></td>
+<td class="signwriting col-signwriting-1">񁭱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00242.html">S19e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00182.html">S120</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00088.html">S170</a></td>
+<td class="signwriting col-signwriting-1">񂨑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00271.html">S1e6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00209.html">S15f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00020.html
+++ b/docs/inventories/inv00020.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>BZhE (SP_134)</title>
+  <title>Inventory: BZhE (SP_134)</title>
   
 <style>
 @font-face {
@@ -12,96 +12,318 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>BZhE (SP_134)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00020</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>BZhE (SP_134)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Bulgarian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_134</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: BZhE (SP_134)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00020</td>
+<td class="col-language-name">Bulgarian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00021.html
+++ b/docs/inventories/inv00021.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LSB (SP_45)</title>
+  <title>Inventory: LSB (SP_45)</title>
   
 <style>
 @font-face {
@@ -12,123 +12,345 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LSB (SP_45)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00021</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LSB (SP_45)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Bolivian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_45</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LSB (SP_45)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00021</td>
+<td class="col-language-name">Bolivian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00022.html
+++ b/docs/inventories/inv00022.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Libras (SP_46)</title>
+  <title>Inventory: Libras (SP_46)</title>
   
 <style>
 @font-face {
@@ -12,2292 +12,2514 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Libras (SP_46)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00022</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>Libras (SP_46)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Brazilian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_46</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: Libras (SP_46)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00022</td>
+<td class="col-language-name">Brazilian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00157.html">S1d3</a></td>
-<td class="signwriting">񄼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00023.html">S1df</a></td>
-<td class="signwriting">񅎱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00065.html">S142</a></td>
-<td class="signwriting">񁣑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00223.html">S175</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00228.html">S17f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00026.html">S1f2</a></td>
-<td class="signwriting">񅫁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00189.html">S133</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00110.html">S1e4</a></td>
-<td class="signwriting">񅖑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00127.html">S173</a></td>
-<td class="signwriting">񂬱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00203.html">S151</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00124.html">S127</a></td>
-<td class="signwriting">񀺱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00222.html">S174</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00153.html">S1c1</a></td>
-<td class="signwriting">񄡱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00140.html">S18b</a></td>
-<td class="signwriting">񃐱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00102.html">S1a7</a></td>
-<td class="signwriting">񃺱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00237.html">S194</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00176.html">S113</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00159.html">S1d8</a></td>
-<td class="signwriting">񅄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00030.html">S198</a></td>
-<td class="signwriting">񃤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00246.html">S1a8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00118.html">S1a3</a></td>
-<td class="signwriting">񃴱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00095.html">S158</a></td>
-<td class="signwriting">񂄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00040.html">S132</a></td>
-<td class="signwriting">񁋑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00224.html">S178</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00227.html">S17b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00183.html">S124</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00082.html">S14b</a></td>
-<td class="signwriting">񁰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00062.html">S122</a></td>
-<td class="signwriting">񀳑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00225.html">S179</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00174.html">S10f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00061.html">S121</a></td>
-<td class="signwriting">񀱱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00142.html">S1a5</a></td>
-<td class="signwriting">񃷱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00014.html">S103</a></td>
-<td class="signwriting">񀄱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00215.html">S166</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00172.html">S109</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00209.html">S15f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00087.html">S16e</a></td>
-<td class="signwriting">񂥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00123.html">S12b</a></td>
-<td class="signwriting">񁀱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00058.html">S112</a></td>
-<td class="signwriting">񀛑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00169.html">S102</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00234.html">S189</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00094.html">S146</a></td>
-<td class="signwriting">񁩑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00206.html">S15b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00261.html">S1c2</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00171.html">S107</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00210.html">S161</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>bent</td>
-<td><a href="../segments/seg00076.html">S190</a></td>
-<td class="signwriting">񃘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00027.html">S1f3</a></td>
-<td class="signwriting">񅬱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00226.html">S17a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00173.html">S10d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00194.html">S138</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00179.html">S11b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00272.html">S1e8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00059.html">S123</a></td>
-<td class="signwriting">񀴱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00221.html">S172</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00216.html">S167</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00048.html">S11d</a></td>
-<td class="signwriting">񀫡</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00260.html">S1c0</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00191.html">S135</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00096.html">S159</a></td>
-<td class="signwriting">񂅱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00184.html">S12c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00245.html">S1a6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00160.html">S105</a></td>
-<td class="signwriting">񀇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00177.html">S114</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00198.html">S13c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00046.html">S116</a></td>
-<td class="signwriting">񀡑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00085.html">S149</a></td>
-<td class="signwriting">񁭱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>extended</td>
-<td><a href="../segments/seg00071.html">S18f</a></td>
-<td class="signwriting">񃖱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00122.html">S12a</a></td>
-<td class="signwriting">񀿑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00088.html">S170</a></td>
-<td class="signwriting">񂨑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00164.html">S14d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00212.html">S163</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00264.html">S1c9</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_nonspread</td>
-<td>extended</td>
-<td><a href="../segments/seg00066.html">S18e</a></td>
-<td class="signwriting">񃕑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00038.html">S1b5</a></td>
-<td class="signwriting">񄏱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00276.html">S1f6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00185.html">S12e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00238.html">S195</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00233.html">S188</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00235.html">S18a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00052.html">S125</a></td>
-<td class="signwriting">񀷱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00181.html">S11f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00230.html">S183</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00199.html">S141</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00211.html">S162</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00170.html">S104</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00190.html">S134</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00041.html">S13e</a></td>
-<td class="signwriting">񁝑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00032.html">S1e2</a></td>
-<td class="signwriting">񅓁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00180.html">S11c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00063.html">S126</a></td>
-<td class="signwriting">񀹑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00161.html">S196</a></td>
-<td class="signwriting">񃡑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00267.html">S1cf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00192.html">S136</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00178.html">S117</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00201.html">S148</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00241.html">S19d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00207.html">S15c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00024.html">S1e0</a></td>
-<td class="signwriting">񅐁</td>
-<td class="signwriting">񅐑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00265.html">S1ca</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00217.html">S169</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00086.html">S168</a></td>
-<td class="signwriting">񂜑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00239.html">S197</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00015.html">S108</a></td>
-<td class="signwriting">񀌑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00254.html">S1b8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00271.html">S1e6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00141.html">S1a4</a></td>
-<td class="signwriting">񃶁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00104.html">S199</a></td>
-<td class="signwriting">񃥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00182.html">S120</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00186.html">S12f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00055.html">S1b0</a></td>
-<td class="signwriting">񄈑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00188.html">S131</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00200.html">S143</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00195.html">S139</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00219.html">S16b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00202.html">S14f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00020.html">S1c6</a></td>
-<td class="signwriting">񄩁</td>
-<td class="signwriting">񄩑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00105.html">S1e5</a></td>
-<td class="signwriting">񅗱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00214.html">S165</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00197.html">S13b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00175.html">S111</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00196.html">S13a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00187.html">S130</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00218.html">S16a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00193.html">S137</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00236.html">S191</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00213.html">S164</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00106.html">S1e7</a></td>
-<td class="signwriting">񅚱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00231.html">S184</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00143.html">S1ba</a></td>
-<td class="signwriting">񄗁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00269.html">S1db</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00244.html">S1a2</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00017.html">S193</a></td>
-<td class="signwriting">񃜱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00167.html">S1cd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00266.html">S1cc</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00109.html">S19f</a></td>
-<td class="signwriting">񃮱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00247.html">S1a9</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00120.html">S1b3</a></td>
-<td class="signwriting">񄌱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00250.html">S1af</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00091.html">S1d7</a></td>
-<td class="signwriting">񅂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00259.html">S1bf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>extended</td>
-<td><a href="../segments/seg00074.html">S1c4</a></td>
-<td class="signwriting">񄦑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00248.html">S1aa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00253.html">S1b7</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00270.html">S1e3</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00147.html">S1d5</a></td>
-<td class="signwriting">񄿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00268.html">S1d9</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00007.html">S1fc</a></td>
-<td class="signwriting">񅺡</td>
-<td class="signwriting">񅺑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00243.html">S1a1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00208.html">S15e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00019.html">S1ae</a></td>
-<td class="signwriting">񄅑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00240.html">S19b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00242.html">S19e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00057.html">S1cb</a></td>
-<td class="signwriting">񄰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00256.html">S1bc</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00008.html">S1fd</a></td>
-<td class="signwriting">񅼁</td>
-<td class="signwriting">񅻱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00258.html">S1be</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00056.html">S1b4</a></td>
-<td class="signwriting">񄎑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00263.html">S1c8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00009.html">S1ff</a></td>
-<td class="signwriting">񅾱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00249.html">S1ac</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00255.html">S1b9</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00119.html">S1b2</a></td>
-<td class="signwriting">񄋑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>extended</td>
-<td><a href="../segments/seg00073.html">S1ab</a></td>
-<td class="signwriting">񄀱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00157.html">S1d3</a></td>
+<td class="signwriting col-signwriting-1">񄼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00023.html">S1df</a></td>
+<td class="signwriting col-signwriting-1">񅎱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00065.html">S142</a></td>
+<td class="signwriting col-signwriting-1">񁣑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00223.html">S175</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00228.html">S17f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00026.html">S1f2</a></td>
+<td class="signwriting col-signwriting-1">񅫁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00189.html">S133</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00110.html">S1e4</a></td>
+<td class="signwriting col-signwriting-1">񅖑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00127.html">S173</a></td>
+<td class="signwriting col-signwriting-1">񂬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00203.html">S151</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00124.html">S127</a></td>
+<td class="signwriting col-signwriting-1">񀺱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00222.html">S174</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00153.html">S1c1</a></td>
+<td class="signwriting col-signwriting-1">񄡱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00140.html">S18b</a></td>
+<td class="signwriting col-signwriting-1">񃐱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00102.html">S1a7</a></td>
+<td class="signwriting col-signwriting-1">񃺱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00237.html">S194</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00176.html">S113</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00159.html">S1d8</a></td>
+<td class="signwriting col-signwriting-1">񅄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00030.html">S198</a></td>
+<td class="signwriting col-signwriting-1">񃤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00246.html">S1a8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00118.html">S1a3</a></td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00095.html">S158</a></td>
+<td class="signwriting col-signwriting-1">񂄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00040.html">S132</a></td>
+<td class="signwriting col-signwriting-1">񁋑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00224.html">S178</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00227.html">S17b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00183.html">S124</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00082.html">S14b</a></td>
+<td class="signwriting col-signwriting-1">񁰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00062.html">S122</a></td>
+<td class="signwriting col-signwriting-1">񀳑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00225.html">S179</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00174.html">S10f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00061.html">S121</a></td>
+<td class="signwriting col-signwriting-1">񀱱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00142.html">S1a5</a></td>
+<td class="signwriting col-signwriting-1">񃷱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00014.html">S103</a></td>
+<td class="signwriting col-signwriting-1">񀄱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00215.html">S166</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00172.html">S109</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00209.html">S15f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00087.html">S16e</a></td>
+<td class="signwriting col-signwriting-1">񂥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00123.html">S12b</a></td>
+<td class="signwriting col-signwriting-1">񁀱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00058.html">S112</a></td>
+<td class="signwriting col-signwriting-1">񀛑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00169.html">S102</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00234.html">S189</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00094.html">S146</a></td>
+<td class="signwriting col-signwriting-1">񁩑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00206.html">S15b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00261.html">S1c2</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00171.html">S107</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00210.html">S161</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">bent</td>
+<td class="col-fsw"><a href="../segments/seg00076.html">S190</a></td>
+<td class="signwriting col-signwriting-1">񃘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00027.html">S1f3</a></td>
+<td class="signwriting col-signwriting-1">񅬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00226.html">S17a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00173.html">S10d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00194.html">S138</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00179.html">S11b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00272.html">S1e8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00059.html">S123</a></td>
+<td class="signwriting col-signwriting-1">񀴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00221.html">S172</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00216.html">S167</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00048.html">S11d</a></td>
+<td class="signwriting col-signwriting-1">񀫡</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00260.html">S1c0</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00191.html">S135</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00096.html">S159</a></td>
+<td class="signwriting col-signwriting-1">񂅱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00184.html">S12c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00245.html">S1a6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00160.html">S105</a></td>
+<td class="signwriting col-signwriting-1">񀇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00177.html">S114</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00198.html">S13c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00046.html">S116</a></td>
+<td class="signwriting col-signwriting-1">񀡑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00085.html">S149</a></td>
+<td class="signwriting col-signwriting-1">񁭱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00071.html">S18f</a></td>
+<td class="signwriting col-signwriting-1">񃖱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00122.html">S12a</a></td>
+<td class="signwriting col-signwriting-1">񀿑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00088.html">S170</a></td>
+<td class="signwriting col-signwriting-1">񂨑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00164.html">S14d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00212.html">S163</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00264.html">S1c9</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00066.html">S18e</a></td>
+<td class="signwriting col-signwriting-1">񃕑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00038.html">S1b5</a></td>
+<td class="signwriting col-signwriting-1">񄏱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00276.html">S1f6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00185.html">S12e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00238.html">S195</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00233.html">S188</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00235.html">S18a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00052.html">S125</a></td>
+<td class="signwriting col-signwriting-1">񀷱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00181.html">S11f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00230.html">S183</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00199.html">S141</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00211.html">S162</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00170.html">S104</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00190.html">S134</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00041.html">S13e</a></td>
+<td class="signwriting col-signwriting-1">񁝑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00032.html">S1e2</a></td>
+<td class="signwriting col-signwriting-1">񅓁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00180.html">S11c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00063.html">S126</a></td>
+<td class="signwriting col-signwriting-1">񀹑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00161.html">S196</a></td>
+<td class="signwriting col-signwriting-1">񃡑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00267.html">S1cf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00192.html">S136</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00178.html">S117</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00201.html">S148</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00241.html">S19d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00207.html">S15c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00024.html">S1e0</a></td>
+<td class="signwriting col-signwriting-1">񅐁</td>
+<td class="signwriting col-signwriting-2">񅐑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00265.html">S1ca</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00217.html">S169</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00086.html">S168</a></td>
+<td class="signwriting col-signwriting-1">񂜑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00239.html">S197</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00015.html">S108</a></td>
+<td class="signwriting col-signwriting-1">񀌑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00254.html">S1b8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00271.html">S1e6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00141.html">S1a4</a></td>
+<td class="signwriting col-signwriting-1">񃶁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00104.html">S199</a></td>
+<td class="signwriting col-signwriting-1">񃥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00182.html">S120</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00186.html">S12f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00055.html">S1b0</a></td>
+<td class="signwriting col-signwriting-1">񄈑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00188.html">S131</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00200.html">S143</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00195.html">S139</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00219.html">S16b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00202.html">S14f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00020.html">S1c6</a></td>
+<td class="signwriting col-signwriting-1">񄩁</td>
+<td class="signwriting col-signwriting-2">񄩑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00105.html">S1e5</a></td>
+<td class="signwriting col-signwriting-1">񅗱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00214.html">S165</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00197.html">S13b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00175.html">S111</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00196.html">S13a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00187.html">S130</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00218.html">S16a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00193.html">S137</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00236.html">S191</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00213.html">S164</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00106.html">S1e7</a></td>
+<td class="signwriting col-signwriting-1">񅚱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00231.html">S184</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00143.html">S1ba</a></td>
+<td class="signwriting col-signwriting-1">񄗁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00269.html">S1db</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00244.html">S1a2</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00017.html">S193</a></td>
+<td class="signwriting col-signwriting-1">񃜱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00167.html">S1cd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00266.html">S1cc</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00109.html">S19f</a></td>
+<td class="signwriting col-signwriting-1">񃮱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00247.html">S1a9</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00120.html">S1b3</a></td>
+<td class="signwriting col-signwriting-1">񄌱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00250.html">S1af</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00091.html">S1d7</a></td>
+<td class="signwriting col-signwriting-1">񅂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00259.html">S1bf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00074.html">S1c4</a></td>
+<td class="signwriting col-signwriting-1">񄦑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00248.html">S1aa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00253.html">S1b7</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00270.html">S1e3</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00147.html">S1d5</a></td>
+<td class="signwriting col-signwriting-1">񄿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00268.html">S1d9</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00007.html">S1fc</a></td>
+<td class="signwriting col-signwriting-1">񅺡</td>
+<td class="signwriting col-signwriting-2">񅺑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00243.html">S1a1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00208.html">S15e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00019.html">S1ae</a></td>
+<td class="signwriting col-signwriting-1">񄅑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00240.html">S19b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00242.html">S19e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00057.html">S1cb</a></td>
+<td class="signwriting col-signwriting-1">񄰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00256.html">S1bc</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00008.html">S1fd</a></td>
+<td class="signwriting col-signwriting-1">񅼁</td>
+<td class="signwriting col-signwriting-2">񅻱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00258.html">S1be</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00056.html">S1b4</a></td>
+<td class="signwriting col-signwriting-1">񄎑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00263.html">S1c8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00009.html">S1ff</a></td>
+<td class="signwriting col-signwriting-1">񅾱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00249.html">S1ac</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00255.html">S1b9</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00119.html">S1b2</a></td>
+<td class="signwriting col-signwriting-1">񄋑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00073.html">S1ab</a></td>
+<td class="signwriting col-signwriting-1">񄀱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00023.html
+++ b/docs/inventories/inv00023.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ASL (SP_4)</title>
+  <title>Inventory: ASL (SP_4)</title>
   
 <style>
 @font-face {
@@ -12,1707 +12,1929 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>ASL (SP_4)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00023</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>ASL (SP_4)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>American Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_4</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: ASL (SP_4)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00023</td>
+<td class="col-language-name">American Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00142.html">S1a5</a></td>
-<td class="signwriting">񃷱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00065.html">S142</a></td>
-<td class="signwriting">񁣑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00207.html">S15c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00153.html">S1c1</a></td>
-<td class="signwriting">񄡱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00082.html">S14b</a></td>
-<td class="signwriting">񁰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00203.html">S151</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00040.html">S132</a></td>
-<td class="signwriting">񁋑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00062.html">S122</a></td>
-<td class="signwriting">񀳑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00127.html">S173</a></td>
-<td class="signwriting">񂬱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00164.html">S14d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00143.html">S1ba</a></td>
-<td class="signwriting">񄗁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00224.html">S178</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00167.html">S1cd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00061.html">S121</a></td>
-<td class="signwriting">񀱱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00228.html">S17f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00095.html">S158</a></td>
-<td class="signwriting">񂄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00094.html">S146</a></td>
-<td class="signwriting">񁩑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00241.html">S19d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00181.html">S11f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00216.html">S167</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00087.html">S16e</a></td>
-<td class="signwriting">񂥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00024.html">S1e0</a></td>
-<td class="signwriting">񅐁</td>
-<td class="signwriting">񅐑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00206.html">S15b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00219.html">S16b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00223.html">S175</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00194.html">S138</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00140.html">S18b</a></td>
-<td class="signwriting">񃐱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00208.html">S15e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00174.html">S10f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00271.html">S1e6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00096.html">S159</a></td>
-<td class="signwriting">񂅱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00215.html">S166</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00105.html">S1e5</a></td>
-<td class="signwriting">񅗱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00225.html">S179</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00240.html">S19b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00058.html">S112</a></td>
-<td class="signwriting">񀛑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00260.html">S1c0</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00212.html">S163</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>bent</td>
-<td><a href="../segments/seg00076.html">S190</a></td>
-<td class="signwriting">񃘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00214.html">S165</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00019.html">S1ae</a></td>
-<td class="signwriting">񄅑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00184.html">S12c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00246.html">S1a8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00189.html">S133</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00183.html">S124</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00257.html">S1bd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00267.html">S1cf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>extended</td>
-<td><a href="../segments/seg00074.html">S1c4</a></td>
-<td class="signwriting">񄦑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00176.html">S113</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00141.html">S1a4</a></td>
-<td class="signwriting">񃶁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00211.html">S162</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00227.html">S17b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00202.html">S14f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00264.html">S1c9</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00026.html">S1f2</a></td>
-<td class="signwriting">񅫁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00190.html">S134</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00157.html">S1d3</a></td>
-<td class="signwriting">񄼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00230.html">S183</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00173.html">S10d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00270.html">S1e3</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00261.html">S1c2</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00122.html">S12a</a></td>
-<td class="signwriting">񀿑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00057.html">S1cb</a></td>
-<td class="signwriting">񄰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00007.html">S1fc</a></td>
-<td class="signwriting">񅺡</td>
-<td class="signwriting">񅺑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00014.html">S103</a></td>
-<td class="signwriting">񀄱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00276.html">S1f6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>extended</td>
-<td><a href="../segments/seg00073.html">S1ab</a></td>
-<td class="signwriting">񄀱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_nonspread</td>
-<td>extended</td>
-<td><a href="../segments/seg00066.html">S18e</a></td>
-<td class="signwriting">񃕑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00032.html">S1e2</a></td>
-<td class="signwriting">񅓁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00191.html">S135</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00209.html">S15f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00106.html">S1e7</a></td>
-<td class="signwriting">񅚱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00268.html">S1d9</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00038.html">S1b5</a></td>
-<td class="signwriting">񄏱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00160.html">S105</a></td>
-<td class="signwriting">񀇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00041.html">S13e</a></td>
-<td class="signwriting">񁝑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00059.html">S123</a></td>
-<td class="signwriting">񀴱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00119.html">S1b2</a></td>
-<td class="signwriting">񄋑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00256.html">S1bc</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00118.html">S1a3</a></td>
-<td class="signwriting">񃴱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00226.html">S17a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00221.html">S172</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00237.html">S194</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00027.html">S1f3</a></td>
-<td class="signwriting">񅬱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00243.html">S1a1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00020.html">S1c6</a></td>
-<td class="signwriting">񄩁</td>
-<td class="signwriting">񄩑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00055.html">S1b0</a></td>
-<td class="signwriting">񄈑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00177.html">S114</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00102.html">S1a7</a></td>
-<td class="signwriting">񃺱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00009.html">S1ff</a></td>
-<td class="signwriting">񅾱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00030.html">S198</a></td>
-<td class="signwriting">񃤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00233.html">S188</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00179.html">S11b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00247.html">S1a9</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00148.html">S1d6</a></td>
-<td class="signwriting">񅁑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00222.html">S174</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00048.html">S11d</a></td>
-<td class="signwriting">񀫡</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00008.html">S1fd</a></td>
-<td class="signwriting">񅼁</td>
-<td class="signwriting">񅻱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00266.html">S1cc</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00142.html">S1a5</a></td>
+<td class="signwriting col-signwriting-1">񃷱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00065.html">S142</a></td>
+<td class="signwriting col-signwriting-1">񁣑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00207.html">S15c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00153.html">S1c1</a></td>
+<td class="signwriting col-signwriting-1">񄡱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00082.html">S14b</a></td>
+<td class="signwriting col-signwriting-1">񁰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00203.html">S151</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00040.html">S132</a></td>
+<td class="signwriting col-signwriting-1">񁋑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00062.html">S122</a></td>
+<td class="signwriting col-signwriting-1">񀳑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00127.html">S173</a></td>
+<td class="signwriting col-signwriting-1">񂬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00164.html">S14d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00143.html">S1ba</a></td>
+<td class="signwriting col-signwriting-1">񄗁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00224.html">S178</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00167.html">S1cd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00061.html">S121</a></td>
+<td class="signwriting col-signwriting-1">񀱱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00228.html">S17f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00095.html">S158</a></td>
+<td class="signwriting col-signwriting-1">񂄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00094.html">S146</a></td>
+<td class="signwriting col-signwriting-1">񁩑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00241.html">S19d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00181.html">S11f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00216.html">S167</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00087.html">S16e</a></td>
+<td class="signwriting col-signwriting-1">񂥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00024.html">S1e0</a></td>
+<td class="signwriting col-signwriting-1">񅐁</td>
+<td class="signwriting col-signwriting-2">񅐑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00206.html">S15b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00219.html">S16b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00223.html">S175</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00194.html">S138</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00140.html">S18b</a></td>
+<td class="signwriting col-signwriting-1">񃐱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00208.html">S15e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00174.html">S10f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00271.html">S1e6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00096.html">S159</a></td>
+<td class="signwriting col-signwriting-1">񂅱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00215.html">S166</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00105.html">S1e5</a></td>
+<td class="signwriting col-signwriting-1">񅗱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00225.html">S179</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00240.html">S19b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00058.html">S112</a></td>
+<td class="signwriting col-signwriting-1">񀛑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00260.html">S1c0</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00212.html">S163</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">bent</td>
+<td class="col-fsw"><a href="../segments/seg00076.html">S190</a></td>
+<td class="signwriting col-signwriting-1">񃘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00214.html">S165</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00019.html">S1ae</a></td>
+<td class="signwriting col-signwriting-1">񄅑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00184.html">S12c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00246.html">S1a8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00189.html">S133</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00183.html">S124</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00257.html">S1bd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00267.html">S1cf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00074.html">S1c4</a></td>
+<td class="signwriting col-signwriting-1">񄦑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00176.html">S113</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00141.html">S1a4</a></td>
+<td class="signwriting col-signwriting-1">񃶁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00211.html">S162</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00227.html">S17b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00202.html">S14f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00264.html">S1c9</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00026.html">S1f2</a></td>
+<td class="signwriting col-signwriting-1">񅫁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00190.html">S134</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00157.html">S1d3</a></td>
+<td class="signwriting col-signwriting-1">񄼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00230.html">S183</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00173.html">S10d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00270.html">S1e3</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00261.html">S1c2</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00122.html">S12a</a></td>
+<td class="signwriting col-signwriting-1">񀿑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00057.html">S1cb</a></td>
+<td class="signwriting col-signwriting-1">񄰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00007.html">S1fc</a></td>
+<td class="signwriting col-signwriting-1">񅺡</td>
+<td class="signwriting col-signwriting-2">񅺑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00014.html">S103</a></td>
+<td class="signwriting col-signwriting-1">񀄱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00276.html">S1f6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00073.html">S1ab</a></td>
+<td class="signwriting col-signwriting-1">񄀱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00066.html">S18e</a></td>
+<td class="signwriting col-signwriting-1">񃕑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00032.html">S1e2</a></td>
+<td class="signwriting col-signwriting-1">񅓁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00191.html">S135</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00209.html">S15f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00106.html">S1e7</a></td>
+<td class="signwriting col-signwriting-1">񅚱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00268.html">S1d9</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00038.html">S1b5</a></td>
+<td class="signwriting col-signwriting-1">񄏱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00160.html">S105</a></td>
+<td class="signwriting col-signwriting-1">񀇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00041.html">S13e</a></td>
+<td class="signwriting col-signwriting-1">񁝑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00059.html">S123</a></td>
+<td class="signwriting col-signwriting-1">񀴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00119.html">S1b2</a></td>
+<td class="signwriting col-signwriting-1">񄋑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00256.html">S1bc</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00118.html">S1a3</a></td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00226.html">S17a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00221.html">S172</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00237.html">S194</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00027.html">S1f3</a></td>
+<td class="signwriting col-signwriting-1">񅬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00243.html">S1a1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00020.html">S1c6</a></td>
+<td class="signwriting col-signwriting-1">񄩁</td>
+<td class="signwriting col-signwriting-2">񄩑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00055.html">S1b0</a></td>
+<td class="signwriting col-signwriting-1">񄈑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00177.html">S114</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00102.html">S1a7</a></td>
+<td class="signwriting col-signwriting-1">񃺱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00009.html">S1ff</a></td>
+<td class="signwriting col-signwriting-1">񅾱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00030.html">S198</a></td>
+<td class="signwriting col-signwriting-1">񃤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00233.html">S188</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00179.html">S11b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00247.html">S1a9</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00148.html">S1d6</a></td>
+<td class="signwriting col-signwriting-1">񅁑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00222.html">S174</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00048.html">S11d</a></td>
+<td class="signwriting col-signwriting-1">񀫡</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00008.html">S1fd</a></td>
+<td class="signwriting col-signwriting-1">񅼁</td>
+<td class="signwriting col-signwriting-2">񅻱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00266.html">S1cc</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00024.html
+++ b/docs/inventories/inv00024.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LSQ (SP_47)</title>
+  <title>Inventory: LSQ (SP_47)</title>
   
 <style>
 @font-face {
@@ -12,1500 +12,1722 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LSQ (SP_47)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00024</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LSQ (SP_47)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Quebec Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_47</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LSQ (SP_47)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00024</td>
+<td class="col-language-name">Quebec Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00087.html">S16e</a></td>
-<td class="signwriting">񂥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00095.html">S158</a></td>
-<td class="signwriting">񂄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00272.html">S1e8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00082.html">S14b</a></td>
-<td class="signwriting">񁰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00267.html">S1cf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00226.html">S17a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00062.html">S122</a></td>
-<td class="signwriting">񀳑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00222.html">S174</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00228.html">S17f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00224.html">S178</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00040.html">S132</a></td>
-<td class="signwriting">񁋑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00065.html">S142</a></td>
-<td class="signwriting">񁣑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00142.html">S1a5</a></td>
-<td class="signwriting">񃷱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00260.html">S1c0</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00122.html">S12a</a></td>
-<td class="signwriting">񀿑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00032.html">S1e2</a></td>
-<td class="signwriting">񅓁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00106.html">S1e7</a></td>
-<td class="signwriting">񅚱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00271.html">S1e6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00088.html">S170</a></td>
-<td class="signwriting">񂨑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00227.html">S17b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00216.html">S167</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00026.html">S1f2</a></td>
-<td class="signwriting">񅫁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00256.html">S1bc</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00189.html">S133</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00061.html">S121</a></td>
-<td class="signwriting">񀱱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00218.html">S16a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00030.html">S198</a></td>
-<td class="signwriting">񃤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00153.html">S1c1</a></td>
-<td class="signwriting">񄡱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00177.html">S114</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00215.html">S166</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00176.html">S113</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00223.html">S175</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00221.html">S172</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00183.html">S124</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00086.html">S168</a></td>
-<td class="signwriting">񂜑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00217.html">S169</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>extended</td>
-<td><a href="../segments/seg00074.html">S1c4</a></td>
-<td class="signwriting">񄦑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00171.html">S107</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00123.html">S12b</a></td>
-<td class="signwriting">񁀱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00059.html">S123</a></td>
-<td class="signwriting">񀴱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00105.html">S1e5</a></td>
-<td class="signwriting">񅗱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00058.html">S112</a></td>
-<td class="signwriting">񀛑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00127.html">S173</a></td>
-<td class="signwriting">񂬱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00212.html">S163</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00094.html">S146</a></td>
-<td class="signwriting">񁩑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00270.html">S1e3</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00140.html">S18b</a></td>
-<td class="signwriting">񃐱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00219.html">S16b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00023.html">S1df</a></td>
-<td class="signwriting">񅎱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00167.html">S1cd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00225.html">S179</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00024.html">S1e0</a></td>
-<td class="signwriting">񅐁</td>
-<td class="signwriting">񅐑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00236.html">S191</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00240.html">S19b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00110.html">S1e4</a></td>
-<td class="signwriting">񅖑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00248.html">S1aa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00190.html">S134</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00118.html">S1a3</a></td>
-<td class="signwriting">񃴱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00143.html">S1ba</a></td>
-<td class="signwriting">񄗁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00141.html">S1a4</a></td>
-<td class="signwriting">񃶁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00203.html">S151</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00184.html">S12c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00027.html">S1f3</a></td>
-<td class="signwriting">񅬱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00278.html">S1fe</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00185.html">S12e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00241.html">S19d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00245.html">S1a6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00233.html">S188</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00160.html">S105</a></td>
-<td class="signwriting">񀇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00170.html">S104</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00014.html">S103</a></td>
-<td class="signwriting">񀄱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00015.html">S108</a></td>
-<td class="signwriting">񀌑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00169.html">S102</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00173.html">S10d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00206.html">S15b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00195.html">S139</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00087.html">S16e</a></td>
+<td class="signwriting col-signwriting-1">񂥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00095.html">S158</a></td>
+<td class="signwriting col-signwriting-1">񂄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00272.html">S1e8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00082.html">S14b</a></td>
+<td class="signwriting col-signwriting-1">񁰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00267.html">S1cf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00226.html">S17a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00062.html">S122</a></td>
+<td class="signwriting col-signwriting-1">񀳑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00222.html">S174</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00228.html">S17f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00224.html">S178</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00040.html">S132</a></td>
+<td class="signwriting col-signwriting-1">񁋑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00065.html">S142</a></td>
+<td class="signwriting col-signwriting-1">񁣑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00142.html">S1a5</a></td>
+<td class="signwriting col-signwriting-1">񃷱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00260.html">S1c0</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00122.html">S12a</a></td>
+<td class="signwriting col-signwriting-1">񀿑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00032.html">S1e2</a></td>
+<td class="signwriting col-signwriting-1">񅓁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00106.html">S1e7</a></td>
+<td class="signwriting col-signwriting-1">񅚱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00271.html">S1e6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00088.html">S170</a></td>
+<td class="signwriting col-signwriting-1">񂨑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00227.html">S17b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00216.html">S167</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00026.html">S1f2</a></td>
+<td class="signwriting col-signwriting-1">񅫁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00256.html">S1bc</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00189.html">S133</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00061.html">S121</a></td>
+<td class="signwriting col-signwriting-1">񀱱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00218.html">S16a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00030.html">S198</a></td>
+<td class="signwriting col-signwriting-1">񃤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00153.html">S1c1</a></td>
+<td class="signwriting col-signwriting-1">񄡱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00177.html">S114</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00215.html">S166</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00176.html">S113</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00223.html">S175</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00221.html">S172</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00183.html">S124</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00086.html">S168</a></td>
+<td class="signwriting col-signwriting-1">񂜑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00217.html">S169</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00074.html">S1c4</a></td>
+<td class="signwriting col-signwriting-1">񄦑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00171.html">S107</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00123.html">S12b</a></td>
+<td class="signwriting col-signwriting-1">񁀱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00059.html">S123</a></td>
+<td class="signwriting col-signwriting-1">񀴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00105.html">S1e5</a></td>
+<td class="signwriting col-signwriting-1">񅗱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00058.html">S112</a></td>
+<td class="signwriting col-signwriting-1">񀛑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00127.html">S173</a></td>
+<td class="signwriting col-signwriting-1">񂬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00212.html">S163</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00094.html">S146</a></td>
+<td class="signwriting col-signwriting-1">񁩑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00270.html">S1e3</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00140.html">S18b</a></td>
+<td class="signwriting col-signwriting-1">񃐱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00219.html">S16b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00023.html">S1df</a></td>
+<td class="signwriting col-signwriting-1">񅎱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00167.html">S1cd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00225.html">S179</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00024.html">S1e0</a></td>
+<td class="signwriting col-signwriting-1">񅐁</td>
+<td class="signwriting col-signwriting-2">񅐑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00236.html">S191</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00240.html">S19b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00110.html">S1e4</a></td>
+<td class="signwriting col-signwriting-1">񅖑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00248.html">S1aa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00190.html">S134</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00118.html">S1a3</a></td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00143.html">S1ba</a></td>
+<td class="signwriting col-signwriting-1">񄗁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00141.html">S1a4</a></td>
+<td class="signwriting col-signwriting-1">񃶁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00203.html">S151</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00184.html">S12c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00027.html">S1f3</a></td>
+<td class="signwriting col-signwriting-1">񅬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00278.html">S1fe</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00185.html">S12e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00241.html">S19d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00245.html">S1a6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00233.html">S188</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00160.html">S105</a></td>
+<td class="signwriting col-signwriting-1">񀇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00170.html">S104</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00014.html">S103</a></td>
+<td class="signwriting col-signwriting-1">񀄱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00015.html">S108</a></td>
+<td class="signwriting col-signwriting-1">񀌑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00169.html">S102</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00173.html">S10d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00206.html">S15b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00195.html">S139</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00025.html
+++ b/docs/inventories/inv00025.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DSGS (SP_48)</title>
+  <title>Inventory: DSGS (SP_48)</title>
   
 <style>
 @font-face {
@@ -12,834 +12,1056 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>DSGS (SP_48)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00025</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>DSGS (SP_48)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Swiss-German Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_48</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: DSGS (SP_48)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00025</td>
+<td class="col-language-name">Swiss-German Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00224.html">S178</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00227.html">S17b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00174.html">S10f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00267.html">S1cf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00147.html">S1d5</a></td>
-<td class="signwriting">񄿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00215.html">S166</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00105.html">S1e5</a></td>
-<td class="signwriting">񅗱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00065.html">S142</a></td>
-<td class="signwriting">񁣑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00246.html">S1a8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00088.html">S170</a></td>
-<td class="signwriting">񂨑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00086.html">S168</a></td>
-<td class="signwriting">񂜑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00241.html">S19d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00148.html">S1d6</a></td>
-<td class="signwriting">񅁑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00224.html">S178</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00227.html">S17b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00174.html">S10f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00267.html">S1cf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00147.html">S1d5</a></td>
+<td class="signwriting col-signwriting-1">񄿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00215.html">S166</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00105.html">S1e5</a></td>
+<td class="signwriting col-signwriting-1">񅗱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00065.html">S142</a></td>
+<td class="signwriting col-signwriting-1">񁣑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00246.html">S1a8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00088.html">S170</a></td>
+<td class="signwriting col-signwriting-1">񂨑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00086.html">S168</a></td>
+<td class="signwriting col-signwriting-1">񂜑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00241.html">S19d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00148.html">S1d6</a></td>
+<td class="signwriting col-signwriting-1">񅁑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00026.html
+++ b/docs/inventories/inv00026.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LSF-SR (SP_49)</title>
+  <title>Inventory: LSF-SR (SP_49)</title>
   
 <style>
 @font-face {
@@ -12,1410 +12,1632 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LSF-SR (SP_49)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00026</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LSF-SR (SP_49)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Swiss-French Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_49</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LSF-SR (SP_49)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00026</td>
+<td class="col-language-name">Swiss-French Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00228.html">S17f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00127.html">S173</a></td>
-<td class="signwriting">񂬱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00082.html">S14b</a></td>
-<td class="signwriting">񁰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00026.html">S1f2</a></td>
-<td class="signwriting">񅫁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00267.html">S1cf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00208.html">S15e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00224.html">S178</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00256.html">S1bc</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00223.html">S175</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00241.html">S19d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00040.html">S132</a></td>
-<td class="signwriting">񁋑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00123.html">S12b</a></td>
-<td class="signwriting">񁀱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00183.html">S124</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00065.html">S142</a></td>
-<td class="signwriting">񁣑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00095.html">S158</a></td>
-<td class="signwriting">񂄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00230.html">S183</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00086.html">S168</a></td>
-<td class="signwriting">񂜑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00088.html">S170</a></td>
-<td class="signwriting">񂨑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00059.html">S123</a></td>
-<td class="signwriting">񀴱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00174.html">S10f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00216.html">S167</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00094.html">S146</a></td>
-<td class="signwriting">񁩑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00207.html">S15c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00062.html">S122</a></td>
-<td class="signwriting">񀳑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00271.html">S1e6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00222.html">S174</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00225.html">S179</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00058.html">S112</a></td>
-<td class="signwriting">񀛑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00118.html">S1a3</a></td>
-<td class="signwriting">񃴱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00185.html">S12e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00106.html">S1e7</a></td>
-<td class="signwriting">񅚱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00153.html">S1c1</a></td>
-<td class="signwriting">񄡱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00085.html">S149</a></td>
-<td class="signwriting">񁭱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00023.html">S1df</a></td>
-<td class="signwriting">񅎱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00061.html">S121</a></td>
-<td class="signwriting">񀱱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00276.html">S1f6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00221.html">S172</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00157.html">S1d3</a></td>
-<td class="signwriting">񄼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00032.html">S1e2</a></td>
-<td class="signwriting">񅓁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00147.html">S1d5</a></td>
-<td class="signwriting">񄿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00159.html">S1d8</a></td>
-<td class="signwriting">񅄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00270.html">S1e3</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00014.html">S103</a></td>
-<td class="signwriting">񀄱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00202.html">S14f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00212.html">S163</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00057.html">S1cb</a></td>
-<td class="signwriting">񄰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00226.html">S17a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00110.html">S1e4</a></td>
-<td class="signwriting">񅖑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00215.html">S166</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_nonspread</td>
-<td>extended</td>
-<td><a href="../segments/seg00066.html">S18e</a></td>
-<td class="signwriting">񃕑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00030.html">S198</a></td>
-<td class="signwriting">񃤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00020.html">S1c6</a></td>
-<td class="signwriting">񄩁</td>
-<td class="signwriting">񄩑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00171.html">S107</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00233.html">S188</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00119.html">S1b2</a></td>
-<td class="signwriting">񄋑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00140.html">S18b</a></td>
-<td class="signwriting">񃐱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00217.html">S169</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00124.html">S127</a></td>
-<td class="signwriting">񀺱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00234.html">S189</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00176.html">S113</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00141.html">S1a4</a></td>
-<td class="signwriting">񃶁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00170.html">S104</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00160.html">S105</a></td>
-<td class="signwriting">񀇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>extended</td>
-<td><a href="../segments/seg00074.html">S1c4</a></td>
-<td class="signwriting">񄦑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00167.html">S1cd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00211.html">S162</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00228.html">S17f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00127.html">S173</a></td>
+<td class="signwriting col-signwriting-1">񂬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00082.html">S14b</a></td>
+<td class="signwriting col-signwriting-1">񁰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00026.html">S1f2</a></td>
+<td class="signwriting col-signwriting-1">񅫁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00267.html">S1cf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00208.html">S15e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00224.html">S178</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00256.html">S1bc</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00223.html">S175</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00241.html">S19d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00040.html">S132</a></td>
+<td class="signwriting col-signwriting-1">񁋑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00123.html">S12b</a></td>
+<td class="signwriting col-signwriting-1">񁀱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00183.html">S124</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00065.html">S142</a></td>
+<td class="signwriting col-signwriting-1">񁣑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00095.html">S158</a></td>
+<td class="signwriting col-signwriting-1">񂄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00230.html">S183</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00086.html">S168</a></td>
+<td class="signwriting col-signwriting-1">񂜑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00088.html">S170</a></td>
+<td class="signwriting col-signwriting-1">񂨑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00059.html">S123</a></td>
+<td class="signwriting col-signwriting-1">񀴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00174.html">S10f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00216.html">S167</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00094.html">S146</a></td>
+<td class="signwriting col-signwriting-1">񁩑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00207.html">S15c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00062.html">S122</a></td>
+<td class="signwriting col-signwriting-1">񀳑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00271.html">S1e6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00222.html">S174</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00225.html">S179</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00058.html">S112</a></td>
+<td class="signwriting col-signwriting-1">񀛑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00118.html">S1a3</a></td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00185.html">S12e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00106.html">S1e7</a></td>
+<td class="signwriting col-signwriting-1">񅚱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00153.html">S1c1</a></td>
+<td class="signwriting col-signwriting-1">񄡱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00085.html">S149</a></td>
+<td class="signwriting col-signwriting-1">񁭱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00023.html">S1df</a></td>
+<td class="signwriting col-signwriting-1">񅎱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00061.html">S121</a></td>
+<td class="signwriting col-signwriting-1">񀱱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00276.html">S1f6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00221.html">S172</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00157.html">S1d3</a></td>
+<td class="signwriting col-signwriting-1">񄼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00032.html">S1e2</a></td>
+<td class="signwriting col-signwriting-1">񅓁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00147.html">S1d5</a></td>
+<td class="signwriting col-signwriting-1">񄿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00159.html">S1d8</a></td>
+<td class="signwriting col-signwriting-1">񅄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00270.html">S1e3</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00014.html">S103</a></td>
+<td class="signwriting col-signwriting-1">񀄱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00202.html">S14f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00212.html">S163</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00057.html">S1cb</a></td>
+<td class="signwriting col-signwriting-1">񄰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00226.html">S17a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00110.html">S1e4</a></td>
+<td class="signwriting col-signwriting-1">񅖑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00215.html">S166</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00066.html">S18e</a></td>
+<td class="signwriting col-signwriting-1">񃕑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00030.html">S198</a></td>
+<td class="signwriting col-signwriting-1">񃤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00020.html">S1c6</a></td>
+<td class="signwriting col-signwriting-1">񄩁</td>
+<td class="signwriting col-signwriting-2">񄩑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00171.html">S107</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00233.html">S188</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00119.html">S1b2</a></td>
+<td class="signwriting col-signwriting-1">񄋑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00140.html">S18b</a></td>
+<td class="signwriting col-signwriting-1">񃐱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00217.html">S169</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00124.html">S127</a></td>
+<td class="signwriting col-signwriting-1">񀺱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00234.html">S189</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00176.html">S113</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00141.html">S1a4</a></td>
+<td class="signwriting col-signwriting-1">񃶁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00170.html">S104</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00160.html">S105</a></td>
+<td class="signwriting col-signwriting-1">񀇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00074.html">S1c4</a></td>
+<td class="signwriting col-signwriting-1">񄦑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00167.html">S1cd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00211.html">S162</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00027.html
+++ b/docs/inventories/inv00027.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LIS-SI (SP_50)</title>
+  <title>Inventory: LIS-SI (SP_50)</title>
   
 <style>
 @font-face {
@@ -12,96 +12,318 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LIS-SI (SP_50)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00027</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LIS-SI (SP_50)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Swiss-Italian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_50</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LIS-SI (SP_50)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00027</td>
+<td class="col-language-name">Swiss-Italian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00028.html
+++ b/docs/inventories/inv00028.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LSCh (SP_135)</title>
+  <title>Inventory: LSCh (SP_135)</title>
   
 <style>
 @font-face {
@@ -12,447 +12,669 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LSCh (SP_135)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00028</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LSCh (SP_135)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Chilean Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_135</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LSCh (SP_135)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00028</td>
+<td class="col-language-name">Chilean Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_nonspread</td>
-<td>extended</td>
-<td><a href="../segments/seg00066.html">S18e</a></td>
-<td class="signwriting">񃕑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00066.html">S18e</a></td>
+<td class="signwriting col-signwriting-1">񃕑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00140.html">S18b</a></td>
-<td class="signwriting">񃐱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00140.html">S18b</a></td>
+<td class="signwriting col-signwriting-1">񃐱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00062.html">S122</a></td>
-<td class="signwriting">񀳑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00062.html">S122</a></td>
+<td class="signwriting col-signwriting-1">񀳑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00032.html">S1e2</a></td>
-<td class="signwriting">񅓁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00032.html">S1e2</a></td>
+<td class="signwriting col-signwriting-1">񅓁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00265.html">S1ca</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00265.html">S1ca</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00178.html">S117</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00178.html">S117</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00216.html">S167</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00216.html">S167</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00029.html
+++ b/docs/inventories/inv00029.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>CSL, ZGS (SP_83)</title>
+  <title>Inventory: CSL, ZGS (SP_83)</title>
   
 <style>
 @font-face {
@@ -12,402 +12,624 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>CSL, ZGS (SP_83)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00029</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>CSL, ZGS (SP_83)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Chinese Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_83</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: CSL, ZGS (SP_83)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00029</td>
+<td class="col-language-name">Chinese Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00167.html">S1cd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00167.html">S1cd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00251.html">S1b1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00251.html">S1b1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00007.html">S1fc</a></td>
-<td class="signwriting">񅺡</td>
-<td class="signwriting">񅺑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00007.html">S1fc</a></td>
+<td class="signwriting col-signwriting-1">񅺡</td>
+<td class="signwriting col-signwriting-2">񅺑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00091.html">S1d7</a></td>
-<td class="signwriting">񅂱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00091.html">S1d7</a></td>
+<td class="signwriting col-signwriting-1">񅂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00008.html">S1fd</a></td>
-<td class="signwriting">񅼁</td>
-<td class="signwriting">񅻱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00008.html">S1fd</a></td>
+<td class="signwriting col-signwriting-1">񅼁</td>
+<td class="signwriting col-signwriting-2">񅻱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00243.html">S1a1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00243.html">S1a1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00174.html">S10f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00174.html">S10f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00141.html">S1a4</a></td>
-<td class="signwriting">񃶁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00141.html">S1a4</a></td>
+<td class="signwriting col-signwriting-1">񃶁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00040.html">S132</a></td>
-<td class="signwriting">񁋑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00040.html">S132</a></td>
+<td class="signwriting col-signwriting-1">񁋑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00030.html
+++ b/docs/inventories/inv00030.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LSC (CO) (SP_51)</title>
+  <title>Inventory: LSC (CO) (SP_51)</title>
   
 <style>
 @font-face {
@@ -12,1230 +12,1452 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LSC (CO) (SP_51)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00030</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LSC (CO) (SP_51)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Colombian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_51</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LSC (CO) (SP_51)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00030</td>
+<td class="col-language-name">Colombian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00095.html">S158</a></td>
-<td class="signwriting">񂄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00222.html">S174</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00228.html">S17f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00140.html">S18b</a></td>
-<td class="signwriting">񃐱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00215.html">S166</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00206.html">S15b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00026.html">S1f2</a></td>
-<td class="signwriting">񅫁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00023.html">S1df</a></td>
-<td class="signwriting">񅎱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00087.html">S16e</a></td>
-<td class="signwriting">񂥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00189.html">S133</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00110.html">S1e4</a></td>
-<td class="signwriting">񅖑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00085.html">S149</a></td>
-<td class="signwriting">񁭱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00015.html">S108</a></td>
-<td class="signwriting">񀌑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00032.html">S1e2</a></td>
-<td class="signwriting">񅓁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00082.html">S14b</a></td>
-<td class="signwriting">񁰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00208.html">S15e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00040.html">S132</a></td>
-<td class="signwriting">񁋑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00059.html">S123</a></td>
-<td class="signwriting">񀴱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00224.html">S178</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00271.html">S1e6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00153.html">S1c1</a></td>
-<td class="signwriting">񄡱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00240.html">S19b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00164.html">S14d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00141.html">S1a4</a></td>
-<td class="signwriting">񃶁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00267.html">S1cf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00061.html">S121</a></td>
-<td class="signwriting">񀱱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00183.html">S124</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00030.html">S198</a></td>
-<td class="signwriting">񃤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00038.html">S1b5</a></td>
-<td class="signwriting">񄏱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00058.html">S112</a></td>
-<td class="signwriting">񀛑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00246.html">S1a8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00180.html">S11c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00157.html">S1d3</a></td>
-<td class="signwriting">񄼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00270.html">S1e3</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00048.html">S11d</a></td>
-<td class="signwriting">񀫡</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00124.html">S127</a></td>
-<td class="signwriting">񀺱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00179.html">S11b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00190.html">S134</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00207.html">S15c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00237.html">S194</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00216.html">S167</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00276.html">S1f6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00014.html">S103</a></td>
-<td class="signwriting">񀄱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00173.html">S10d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00221.html">S172</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00203.html">S151</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00086.html">S168</a></td>
-<td class="signwriting">񂜑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00261.html">S1c2</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>extended</td>
-<td><a href="../segments/seg00074.html">S1c4</a></td>
-<td class="signwriting">񄦑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00118.html">S1a3</a></td>
-<td class="signwriting">񃴱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00095.html">S158</a></td>
+<td class="signwriting col-signwriting-1">񂄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00222.html">S174</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00228.html">S17f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00140.html">S18b</a></td>
+<td class="signwriting col-signwriting-1">񃐱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00215.html">S166</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00206.html">S15b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00026.html">S1f2</a></td>
+<td class="signwriting col-signwriting-1">񅫁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00023.html">S1df</a></td>
+<td class="signwriting col-signwriting-1">񅎱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00087.html">S16e</a></td>
+<td class="signwriting col-signwriting-1">񂥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00189.html">S133</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00110.html">S1e4</a></td>
+<td class="signwriting col-signwriting-1">񅖑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00085.html">S149</a></td>
+<td class="signwriting col-signwriting-1">񁭱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00015.html">S108</a></td>
+<td class="signwriting col-signwriting-1">񀌑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00032.html">S1e2</a></td>
+<td class="signwriting col-signwriting-1">񅓁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00082.html">S14b</a></td>
+<td class="signwriting col-signwriting-1">񁰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00208.html">S15e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00040.html">S132</a></td>
+<td class="signwriting col-signwriting-1">񁋑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00059.html">S123</a></td>
+<td class="signwriting col-signwriting-1">񀴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00224.html">S178</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00271.html">S1e6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00153.html">S1c1</a></td>
+<td class="signwriting col-signwriting-1">񄡱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00240.html">S19b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00164.html">S14d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00141.html">S1a4</a></td>
+<td class="signwriting col-signwriting-1">񃶁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00267.html">S1cf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00061.html">S121</a></td>
+<td class="signwriting col-signwriting-1">񀱱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00183.html">S124</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00030.html">S198</a></td>
+<td class="signwriting col-signwriting-1">񃤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00038.html">S1b5</a></td>
+<td class="signwriting col-signwriting-1">񄏱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00058.html">S112</a></td>
+<td class="signwriting col-signwriting-1">񀛑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00246.html">S1a8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00180.html">S11c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00157.html">S1d3</a></td>
+<td class="signwriting col-signwriting-1">񄼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00270.html">S1e3</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00048.html">S11d</a></td>
+<td class="signwriting col-signwriting-1">񀫡</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00124.html">S127</a></td>
+<td class="signwriting col-signwriting-1">񀺱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00179.html">S11b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00190.html">S134</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00207.html">S15c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00237.html">S194</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00216.html">S167</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00276.html">S1f6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00014.html">S103</a></td>
+<td class="signwriting col-signwriting-1">񀄱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00173.html">S10d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00221.html">S172</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00203.html">S151</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00086.html">S168</a></td>
+<td class="signwriting col-signwriting-1">񂜑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00261.html">S1c2</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00074.html">S1c4</a></td>
+<td class="signwriting col-signwriting-1">񄦑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00118.html">S1a3</a></td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00031.html
+++ b/docs/inventories/inv00031.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LESCO (SP_101)</title>
+  <title>Inventory: LESCO (SP_101)</title>
   
 <style>
 @font-face {
@@ -12,87 +12,309 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LESCO (SP_101)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00031</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LESCO (SP_101)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Costa Rican Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_101</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LESCO (SP_101)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00031</td>
+<td class="col-language-name">Costa Rican Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00032.html
+++ b/docs/inventories/inv00032.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ČZJ (SP_52)</title>
+  <title>Inventory: ČZJ (SP_52)</title>
   
 <style>
 @font-face {
@@ -12,1167 +12,1389 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>ČZJ (SP_52)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00032</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>ČZJ (SP_52)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Czech Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_52</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: ČZJ (SP_52)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00032</td>
+<td class="col-language-name">Czech Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00228.html">S17f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00088.html">S170</a></td>
-<td class="signwriting">񂨑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00206.html">S15b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00147.html">S1d5</a></td>
-<td class="signwriting">񄿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00087.html">S16e</a></td>
-<td class="signwriting">񂥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00095.html">S158</a></td>
-<td class="signwriting">񂄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00110.html">S1e4</a></td>
-<td class="signwriting">񅖑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00225.html">S179</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00208.html">S15e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00227.html">S17b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00124.html">S127</a></td>
-<td class="signwriting">񀺱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00202.html">S14f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00216.html">S167</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00123.html">S12b</a></td>
-<td class="signwriting">񁀱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00221.html">S172</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00222.html">S174</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00224.html">S178</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00267.html">S1cf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00030.html">S198</a></td>
-<td class="signwriting">񃤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00062.html">S122</a></td>
-<td class="signwriting">񀳑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00023.html">S1df</a></td>
-<td class="signwriting">񅎱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00153.html">S1c1</a></td>
-<td class="signwriting">񄡱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00127.html">S173</a></td>
-<td class="signwriting">񂬱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00223.html">S175</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00032.html">S1e2</a></td>
-<td class="signwriting">񅓁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00102.html">S1a7</a></td>
-<td class="signwriting">񃺱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00082.html">S14b</a></td>
-<td class="signwriting">񁰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00272.html">S1e8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00226.html">S17a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00164.html">S14d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00190.html">S134</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00241.html">S19d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00270.html">S1e3</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00271.html">S1e6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00191.html">S135</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00105.html">S1e5</a></td>
-<td class="signwriting">񅗱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00096.html">S159</a></td>
-<td class="signwriting">񂅱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00174.html">S10f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00024.html">S1e0</a></td>
-<td class="signwriting">񅐁</td>
-<td class="signwriting">񅐑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00207.html">S15c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00215.html">S166</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00058.html">S112</a></td>
-<td class="signwriting">񀛑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00228.html">S17f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00088.html">S170</a></td>
+<td class="signwriting col-signwriting-1">񂨑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00206.html">S15b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00147.html">S1d5</a></td>
+<td class="signwriting col-signwriting-1">񄿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00087.html">S16e</a></td>
+<td class="signwriting col-signwriting-1">񂥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00095.html">S158</a></td>
+<td class="signwriting col-signwriting-1">񂄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00110.html">S1e4</a></td>
+<td class="signwriting col-signwriting-1">񅖑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00225.html">S179</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00208.html">S15e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00227.html">S17b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00124.html">S127</a></td>
+<td class="signwriting col-signwriting-1">񀺱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00202.html">S14f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00216.html">S167</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00123.html">S12b</a></td>
+<td class="signwriting col-signwriting-1">񁀱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00221.html">S172</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00222.html">S174</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00224.html">S178</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00267.html">S1cf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00030.html">S198</a></td>
+<td class="signwriting col-signwriting-1">񃤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00062.html">S122</a></td>
+<td class="signwriting col-signwriting-1">񀳑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00023.html">S1df</a></td>
+<td class="signwriting col-signwriting-1">񅎱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00153.html">S1c1</a></td>
+<td class="signwriting col-signwriting-1">񄡱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00127.html">S173</a></td>
+<td class="signwriting col-signwriting-1">񂬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00223.html">S175</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00032.html">S1e2</a></td>
+<td class="signwriting col-signwriting-1">񅓁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00102.html">S1a7</a></td>
+<td class="signwriting col-signwriting-1">񃺱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00082.html">S14b</a></td>
+<td class="signwriting col-signwriting-1">񁰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00272.html">S1e8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00226.html">S17a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00164.html">S14d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00190.html">S134</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00241.html">S19d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00270.html">S1e3</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00271.html">S1e6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00191.html">S135</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00105.html">S1e5</a></td>
+<td class="signwriting col-signwriting-1">񅗱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00096.html">S159</a></td>
+<td class="signwriting col-signwriting-1">񂅱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00174.html">S10f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00024.html">S1e0</a></td>
+<td class="signwriting col-signwriting-1">񅐁</td>
+<td class="signwriting col-signwriting-2">񅐑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00207.html">S15c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00215.html">S166</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00058.html">S112</a></td>
+<td class="signwriting col-signwriting-1">񀛑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00033.html
+++ b/docs/inventories/inv00033.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DGS (SP_53)</title>
+  <title>Inventory: DGS (SP_53)</title>
   
 <style>
 @font-face {
@@ -12,942 +12,1164 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>DGS (SP_53)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00033</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>DGS (SP_53)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>German Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_53</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: DGS (SP_53)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00033</td>
+<td class="col-language-name">German Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00095.html">S158</a></td>
-<td class="signwriting">񂄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00228.html">S17f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00026.html">S1f2</a></td>
-<td class="signwriting">񅫁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00223.html">S175</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00110.html">S1e4</a></td>
-<td class="signwriting">񅖑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00032.html">S1e2</a></td>
-<td class="signwriting">񅓁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00153.html">S1c1</a></td>
-<td class="signwriting">񄡱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00256.html">S1bc</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00058.html">S112</a></td>
-<td class="signwriting">񀛑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00217.html">S169</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00106.html">S1e7</a></td>
-<td class="signwriting">񅚱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00167.html">S1cd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00234.html">S189</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00082.html">S14b</a></td>
-<td class="signwriting">񁰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00061.html">S121</a></td>
-<td class="signwriting">񀱱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00246.html">S1a8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00142.html">S1a5</a></td>
-<td class="signwriting">񃷱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00267.html">S1cf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00023.html">S1df</a></td>
-<td class="signwriting">񅎱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00095.html">S158</a></td>
+<td class="signwriting col-signwriting-1">񂄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00228.html">S17f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00026.html">S1f2</a></td>
+<td class="signwriting col-signwriting-1">񅫁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00223.html">S175</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00110.html">S1e4</a></td>
+<td class="signwriting col-signwriting-1">񅖑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00032.html">S1e2</a></td>
+<td class="signwriting col-signwriting-1">񅓁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00153.html">S1c1</a></td>
+<td class="signwriting col-signwriting-1">񄡱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00256.html">S1bc</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00058.html">S112</a></td>
+<td class="signwriting col-signwriting-1">񀛑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00217.html">S169</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00106.html">S1e7</a></td>
+<td class="signwriting col-signwriting-1">񅚱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00167.html">S1cd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00234.html">S189</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00082.html">S14b</a></td>
+<td class="signwriting col-signwriting-1">񁰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00061.html">S121</a></td>
+<td class="signwriting col-signwriting-1">񀱱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00246.html">S1a8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00142.html">S1a5</a></td>
+<td class="signwriting col-signwriting-1">񃷱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00267.html">S1cf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00023.html">S1df</a></td>
+<td class="signwriting col-signwriting-1">񅎱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00034.html
+++ b/docs/inventories/inv00034.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DSL, DTS (SP_30)</title>
+  <title>Inventory: DSL, DTS (SP_30)</title>
   
 <style>
 @font-face {
@@ -12,366 +12,588 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>DSL, DTS (SP_30)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00034</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>DSL, DTS (SP_30)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Danish Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_30</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: DSL, DTS (SP_30)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00034</td>
+<td class="col-language-name">Danish Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00058.html">S112</a></td>
-<td class="signwriting">񀛑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00058.html">S112</a></td>
+<td class="signwriting col-signwriting-1">񀛑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00026.html">S1f2</a></td>
-<td class="signwriting">񅫁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00026.html">S1f2</a></td>
+<td class="signwriting col-signwriting-1">񅫁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00159.html">S1d8</a></td>
-<td class="signwriting">񅄑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00159.html">S1d8</a></td>
+<td class="signwriting col-signwriting-1">񅄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00142.html">S1a5</a></td>
-<td class="signwriting">񃷱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00142.html">S1a5</a></td>
+<td class="signwriting col-signwriting-1">񃷱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00035.html
+++ b/docs/inventories/inv00035.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LSEC (SP_136)</title>
+  <title>Inventory: LSEC (SP_136)</title>
   
 <style>
 @font-face {
@@ -12,96 +12,318 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LSEC (SP_136)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00035</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LSEC (SP_136)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Ecuadorian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_136</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LSEC (SP_136)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00035</td>
+<td class="col-language-name">Ecuadorian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00036.html
+++ b/docs/inventories/inv00036.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>EVK (SP_109)</title>
+  <title>Inventory: EVK (SP_109)</title>
   
 <style>
 @font-face {
@@ -12,96 +12,318 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>EVK (SP_109)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00036</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>EVK (SP_109)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Estonian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_109</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: EVK (SP_109)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00036</td>
+<td class="col-language-name">Estonian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00037.html
+++ b/docs/inventories/inv00037.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ESL (SP_84)</title>
+  <title>Inventory: ESL (SP_84)</title>
   
 <style>
 @font-face {
@@ -12,96 +12,318 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>ESL (SP_84)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00037</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>ESL (SP_84)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Egypt Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_84</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: ESL (SP_84)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00037</td>
+<td class="col-language-name">Egypt Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00038.html
+++ b/docs/inventories/inv00038.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LSE (SP_55)</title>
+  <title>Inventory: LSE (SP_55)</title>
   
 <style>
 @font-face {
@@ -12,1329 +12,1551 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LSE (SP_55)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00038</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LSE (SP_55)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Spanish Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_55</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LSE (SP_55)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00038</td>
+<td class="col-language-name">Spanish Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00241.html">S19d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00267.html">S1cf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00157.html">S1d3</a></td>
-<td class="signwriting">񄼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00276.html">S1f6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00153.html">S1c1</a></td>
-<td class="signwriting">񄡱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00110.html">S1e4</a></td>
-<td class="signwriting">񅖑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00216.html">S167</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00190.html">S134</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00261.html">S1c2</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00245.html">S1a6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00124.html">S127</a></td>
-<td class="signwriting">񀺱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00246.html">S1a8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00227.html">S17b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00228.html">S17f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00127.html">S173</a></td>
-<td class="signwriting">񂬱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00048.html">S11d</a></td>
-<td class="signwriting">񀫡</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00102.html">S1a7</a></td>
-<td class="signwriting">񃺱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00177.html">S114</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00233.html">S188</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00194.html">S138</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00032.html">S1e2</a></td>
-<td class="signwriting">񅓁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>extended</td>
-<td><a href="../segments/seg00074.html">S1c4</a></td>
-<td class="signwriting">񄦑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00217.html">S169</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00223.html">S175</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00065.html">S142</a></td>
-<td class="signwriting">񁣑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00030.html">S198</a></td>
-<td class="signwriting">񃤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00221.html">S172</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_nonspread</td>
-<td>extended</td>
-<td><a href="../segments/seg00066.html">S18e</a></td>
-<td class="signwriting">񃕑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00180.html">S11c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00203.html">S151</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00118.html">S1a3</a></td>
-<td class="signwriting">񃴱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00027.html">S1f3</a></td>
-<td class="signwriting">񅬱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00254.html">S1b8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00057.html">S1cb</a></td>
-<td class="signwriting">񄰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00191.html">S135</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>extended</td>
-<td><a href="../segments/seg00071.html">S18f</a></td>
-<td class="signwriting">񃖱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00202.html">S14f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00230.html">S183</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00213.html">S164</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00167.html">S1cd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00226.html">S17a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00160.html">S105</a></td>
-<td class="signwriting">񀇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00143.html">S1ba</a></td>
-<td class="signwriting">񄗁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00141.html">S1a4</a></td>
-<td class="signwriting">񃶁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00171.html">S107</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00253.html">S1b7</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00264.html">S1c9</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00185.html">S12e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00271.html">S1e6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00120.html">S1b3</a></td>
-<td class="signwriting">񄌱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00088.html">S170</a></td>
-<td class="signwriting">񂨑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00046.html">S116</a></td>
-<td class="signwriting">񀡑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00024.html">S1e0</a></td>
-<td class="signwriting">񅐁</td>
-<td class="signwriting">񅐑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00272.html">S1e8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00206.html">S15b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00259.html">S1bf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00140.html">S18b</a></td>
-<td class="signwriting">񃐱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00105.html">S1e5</a></td>
-<td class="signwriting">񅗱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00234.html">S189</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00019.html">S1ae</a></td>
-<td class="signwriting">񄅑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00123.html">S12b</a></td>
-<td class="signwriting">񁀱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00212.html">S163</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00209.html">S15f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00241.html">S19d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00267.html">S1cf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00157.html">S1d3</a></td>
+<td class="signwriting col-signwriting-1">񄼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00276.html">S1f6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00153.html">S1c1</a></td>
+<td class="signwriting col-signwriting-1">񄡱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00110.html">S1e4</a></td>
+<td class="signwriting col-signwriting-1">񅖑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00216.html">S167</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00190.html">S134</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00261.html">S1c2</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00245.html">S1a6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00124.html">S127</a></td>
+<td class="signwriting col-signwriting-1">񀺱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00246.html">S1a8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00227.html">S17b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00228.html">S17f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00127.html">S173</a></td>
+<td class="signwriting col-signwriting-1">񂬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00048.html">S11d</a></td>
+<td class="signwriting col-signwriting-1">񀫡</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00102.html">S1a7</a></td>
+<td class="signwriting col-signwriting-1">񃺱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00177.html">S114</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00233.html">S188</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00194.html">S138</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00032.html">S1e2</a></td>
+<td class="signwriting col-signwriting-1">񅓁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00074.html">S1c4</a></td>
+<td class="signwriting col-signwriting-1">񄦑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00217.html">S169</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00223.html">S175</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00065.html">S142</a></td>
+<td class="signwriting col-signwriting-1">񁣑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00030.html">S198</a></td>
+<td class="signwriting col-signwriting-1">񃤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00221.html">S172</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00066.html">S18e</a></td>
+<td class="signwriting col-signwriting-1">񃕑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00180.html">S11c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00203.html">S151</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00118.html">S1a3</a></td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00027.html">S1f3</a></td>
+<td class="signwriting col-signwriting-1">񅬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00254.html">S1b8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00057.html">S1cb</a></td>
+<td class="signwriting col-signwriting-1">񄰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00191.html">S135</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00071.html">S18f</a></td>
+<td class="signwriting col-signwriting-1">񃖱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00202.html">S14f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00230.html">S183</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00213.html">S164</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00167.html">S1cd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00226.html">S17a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00160.html">S105</a></td>
+<td class="signwriting col-signwriting-1">񀇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00143.html">S1ba</a></td>
+<td class="signwriting col-signwriting-1">񄗁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00141.html">S1a4</a></td>
+<td class="signwriting col-signwriting-1">񃶁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00171.html">S107</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00253.html">S1b7</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00264.html">S1c9</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00185.html">S12e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00271.html">S1e6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00120.html">S1b3</a></td>
+<td class="signwriting col-signwriting-1">񄌱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00088.html">S170</a></td>
+<td class="signwriting col-signwriting-1">񂨑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00046.html">S116</a></td>
+<td class="signwriting col-signwriting-1">񀡑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00024.html">S1e0</a></td>
+<td class="signwriting col-signwriting-1">񅐁</td>
+<td class="signwriting col-signwriting-2">񅐑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00272.html">S1e8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00206.html">S15b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00259.html">S1bf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00140.html">S18b</a></td>
+<td class="signwriting col-signwriting-1">񃐱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00105.html">S1e5</a></td>
+<td class="signwriting col-signwriting-1">񅗱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00234.html">S189</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00019.html">S1ae</a></td>
+<td class="signwriting col-signwriting-1">񄅑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00123.html">S12b</a></td>
+<td class="signwriting col-signwriting-1">񁀱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00212.html">S163</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00209.html">S15f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00039.html
+++ b/docs/inventories/inv00039.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LSC (CT) (SP_56)</title>
+  <title>Inventory: LSC (CT) (SP_56)</title>
   
 <style>
 @font-face {
@@ -12,1203 +12,1425 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LSC (CT) (SP_56)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00039</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LSC (CT) (SP_56)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Catalan Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_56</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LSC (CT) (SP_56)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00039</td>
+<td class="col-language-name">Catalan Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00173.html">S10d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00153.html">S1c1</a></td>
-<td class="signwriting">񄡱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00216.html">S167</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00267.html">S1cf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00095.html">S158</a></td>
-<td class="signwriting">񂄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00110.html">S1e4</a></td>
-<td class="signwriting">񅖑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00160.html">S105</a></td>
-<td class="signwriting">񀇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00058.html">S112</a></td>
-<td class="signwriting">񀛑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00087.html">S16e</a></td>
-<td class="signwriting">񂥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00224.html">S178</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00221.html">S172</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00190.html">S134</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00082.html">S14b</a></td>
-<td class="signwriting">񁰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00241.html">S19d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00124.html">S127</a></td>
-<td class="signwriting">񀺱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00264.html">S1c9</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00228.html">S17f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00157.html">S1d3</a></td>
-<td class="signwriting">񄼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00180.html">S11c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00040.html">S132</a></td>
-<td class="signwriting">񁋑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00106.html">S1e7</a></td>
-<td class="signwriting">񅚱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00245.html">S1a6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00254.html">S1b8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00120.html">S1b3</a></td>
-<td class="signwriting">񄌱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00181.html">S11f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00225.html">S179</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00227.html">S17b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00048.html">S11d</a></td>
-<td class="signwriting">񀫡</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00061.html">S121</a></td>
-<td class="signwriting">񀱱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00026.html">S1f2</a></td>
-<td class="signwriting">񅫁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00276.html">S1f6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00140.html">S18b</a></td>
-<td class="signwriting">񃐱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00038.html">S1b5</a></td>
-<td class="signwriting">񄏱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00094.html">S146</a></td>
-<td class="signwriting">񁩑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00020.html">S1c6</a></td>
-<td class="signwriting">񄩁</td>
-<td class="signwriting">񄩑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00088.html">S170</a></td>
-<td class="signwriting">񂨑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00019.html">S1ae</a></td>
-<td class="signwriting">񄅑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>extended</td>
-<td><a href="../segments/seg00074.html">S1c4</a></td>
-<td class="signwriting">񄦑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00272.html">S1e8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00171.html">S107</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00127.html">S173</a></td>
-<td class="signwriting">񂬱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00261.html">S1c2</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00046.html">S116</a></td>
-<td class="signwriting">񀡑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00172.html">S109</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00167.html">S1cd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00260.html">S1c0</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00217.html">S169</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00024.html">S1e0</a></td>
-<td class="signwriting">񅐁</td>
-<td class="signwriting">񅐑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00059.html">S123</a></td>
-<td class="signwriting">񀴱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00173.html">S10d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00153.html">S1c1</a></td>
+<td class="signwriting col-signwriting-1">񄡱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00216.html">S167</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00267.html">S1cf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00095.html">S158</a></td>
+<td class="signwriting col-signwriting-1">񂄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00110.html">S1e4</a></td>
+<td class="signwriting col-signwriting-1">񅖑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00160.html">S105</a></td>
+<td class="signwriting col-signwriting-1">񀇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00058.html">S112</a></td>
+<td class="signwriting col-signwriting-1">񀛑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00087.html">S16e</a></td>
+<td class="signwriting col-signwriting-1">񂥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00224.html">S178</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00221.html">S172</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00190.html">S134</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00082.html">S14b</a></td>
+<td class="signwriting col-signwriting-1">񁰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00241.html">S19d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00124.html">S127</a></td>
+<td class="signwriting col-signwriting-1">񀺱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00264.html">S1c9</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00228.html">S17f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00157.html">S1d3</a></td>
+<td class="signwriting col-signwriting-1">񄼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00180.html">S11c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00040.html">S132</a></td>
+<td class="signwriting col-signwriting-1">񁋑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00106.html">S1e7</a></td>
+<td class="signwriting col-signwriting-1">񅚱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00245.html">S1a6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00254.html">S1b8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00120.html">S1b3</a></td>
+<td class="signwriting col-signwriting-1">񄌱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00181.html">S11f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00225.html">S179</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00227.html">S17b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00048.html">S11d</a></td>
+<td class="signwriting col-signwriting-1">񀫡</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00061.html">S121</a></td>
+<td class="signwriting col-signwriting-1">񀱱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00026.html">S1f2</a></td>
+<td class="signwriting col-signwriting-1">񅫁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00276.html">S1f6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00140.html">S18b</a></td>
+<td class="signwriting col-signwriting-1">񃐱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00038.html">S1b5</a></td>
+<td class="signwriting col-signwriting-1">񄏱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00094.html">S146</a></td>
+<td class="signwriting col-signwriting-1">񁩑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00020.html">S1c6</a></td>
+<td class="signwriting col-signwriting-1">񄩁</td>
+<td class="signwriting col-signwriting-2">񄩑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00088.html">S170</a></td>
+<td class="signwriting col-signwriting-1">񂨑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00019.html">S1ae</a></td>
+<td class="signwriting col-signwriting-1">񄅑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00074.html">S1c4</a></td>
+<td class="signwriting col-signwriting-1">񄦑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00272.html">S1e8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00171.html">S107</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00127.html">S173</a></td>
+<td class="signwriting col-signwriting-1">񂬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00261.html">S1c2</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00046.html">S116</a></td>
+<td class="signwriting col-signwriting-1">񀡑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00172.html">S109</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00167.html">S1cd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00260.html">S1c0</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00217.html">S169</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00024.html">S1e0</a></td>
+<td class="signwriting col-signwriting-1">񅐁</td>
+<td class="signwriting col-signwriting-2">񅐑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00059.html">S123</a></td>
+<td class="signwriting col-signwriting-1">񀴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00040.html
+++ b/docs/inventories/inv00040.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>EthSL (SP_18)</title>
+  <title>Inventory: EthSL (SP_18)</title>
   
 <style>
 @font-face {
@@ -12,537 +12,759 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>EthSL (SP_18)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00040</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>EthSL (SP_18)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Ethiopian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_18</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: EthSL (SP_18)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00040</td>
+<td class="col-language-name">Ethiopian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00241.html">S19d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00241.html">S19d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00176.html">S113</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00176.html">S113</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00262.html">S1c7</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00262.html">S1c7</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00267.html">S1cf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00267.html">S1cf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00171.html">S107</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00171.html">S107</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00231.html">S184</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00231.html">S184</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00023.html">S1df</a></td>
-<td class="signwriting">񅎱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00023.html">S1df</a></td>
+<td class="signwriting col-signwriting-1">񅎱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00127.html">S173</a></td>
-<td class="signwriting">񂬱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00127.html">S173</a></td>
+<td class="signwriting col-signwriting-1">񂬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00223.html">S175</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00223.html">S175</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00194.html">S138</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00194.html">S138</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00169.html">S102</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00169.html">S102</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00173.html">S10d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00173.html">S10d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00019.html">S1ae</a></td>
-<td class="signwriting">񄅑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00019.html">S1ae</a></td>
+<td class="signwriting col-signwriting-1">񄅑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00082.html">S14b</a></td>
-<td class="signwriting">񁰱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00082.html">S14b</a></td>
+<td class="signwriting col-signwriting-1">񁰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00055.html">S1b0</a></td>
-<td class="signwriting">񄈑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00055.html">S1b0</a></td>
+<td class="signwriting col-signwriting-1">񄈑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00160.html">S105</a></td>
-<td class="signwriting">񀇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00160.html">S105</a></td>
+<td class="signwriting col-signwriting-1">񀇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00251.html">S1b1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00251.html">S1b1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00211.html">S162</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00211.html">S162</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00041.html
+++ b/docs/inventories/inv00041.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>FinSL (SP_57)</title>
+  <title>Inventory: FinSL (SP_57)</title>
   
 <style>
 @font-face {
@@ -12,429 +12,651 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>FinSL (SP_57)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00041</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>FinSL (SP_57)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Finnish Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_57</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: FinSL (SP_57)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00041</td>
+<td class="col-language-name">Finnish Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00026.html">S1f2</a></td>
-<td class="signwriting">񅫁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00026.html">S1f2</a></td>
+<td class="signwriting col-signwriting-1">񅫁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00267.html">S1cf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00267.html">S1cf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00042.html
+++ b/docs/inventories/inv00042.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LSF (SP_58)</title>
+  <title>Inventory: LSF (SP_58)</title>
   
 <style>
 @font-face {
@@ -12,807 +12,1029 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LSF (SP_58)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00042</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LSF (SP_58)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>French Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_58</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LSF (SP_58)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00042</td>
+<td class="col-language-name">French Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00065.html">S142</a></td>
-<td class="signwriting">񁣑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00209.html">S15f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00241.html">S19d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00118.html">S1a3</a></td>
-<td class="signwriting">񃴱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00254.html">S1b8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00174.html">S10f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00157.html">S1d3</a></td>
-<td class="signwriting">񄼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00024.html">S1e0</a></td>
-<td class="signwriting">񅐁</td>
-<td class="signwriting">񅐑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00086.html">S168</a></td>
-<td class="signwriting">񂜑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00265.html">S1ca</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00225.html">S179</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00062.html">S122</a></td>
-<td class="signwriting">񀳑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00140.html">S18b</a></td>
-<td class="signwriting">񃐱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00023.html">S1df</a></td>
-<td class="signwriting">񅎱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00082.html">S14b</a></td>
-<td class="signwriting">񁰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00095.html">S158</a></td>
-<td class="signwriting">񂄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00065.html">S142</a></td>
+<td class="signwriting col-signwriting-1">񁣑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00209.html">S15f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00241.html">S19d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00118.html">S1a3</a></td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00254.html">S1b8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00174.html">S10f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00157.html">S1d3</a></td>
+<td class="signwriting col-signwriting-1">񄼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00024.html">S1e0</a></td>
+<td class="signwriting col-signwriting-1">񅐁</td>
+<td class="signwriting col-signwriting-2">񅐑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00086.html">S168</a></td>
+<td class="signwriting col-signwriting-1">񂜑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00265.html">S1ca</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00225.html">S179</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00062.html">S122</a></td>
+<td class="signwriting col-signwriting-1">񀳑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00140.html">S18b</a></td>
+<td class="signwriting col-signwriting-1">񃐱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00023.html">S1df</a></td>
+<td class="signwriting col-signwriting-1">񅎱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00082.html">S14b</a></td>
+<td class="signwriting col-signwriting-1">񁰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00095.html">S158</a></td>
+<td class="signwriting col-signwriting-1">񂄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00043.html
+++ b/docs/inventories/inv00043.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>BSL (SP_59)</title>
+  <title>Inventory: BSL (SP_59)</title>
   
 <style>
 @font-face {
@@ -12,870 +12,1092 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>BSL (SP_59)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00043</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>BSL (SP_59)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>British Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_59</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: BSL (SP_59)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00043</td>
+<td class="col-language-name">British Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00030.html">S198</a></td>
-<td class="signwriting">񃤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00207.html">S15c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00269.html">S1db</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00167.html">S1cd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00202.html">S14f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_nonspread</td>
-<td>extended</td>
-<td><a href="../segments/seg00066.html">S18e</a></td>
-<td class="signwriting">񃕑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00055.html">S1b0</a></td>
-<td class="signwriting">񄈑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00140.html">S18b</a></td>
-<td class="signwriting">񃐱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00203.html">S151</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00235.html">S18a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00123.html">S12b</a></td>
-<td class="signwriting">񁀱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00260.html">S1c0</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00040.html">S132</a></td>
-<td class="signwriting">񁋑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00094.html">S146</a></td>
-<td class="signwriting">񁩑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00095.html">S158</a></td>
-<td class="signwriting">񂄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00058.html">S112</a></td>
-<td class="signwriting">񀛑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00153.html">S1c1</a></td>
-<td class="signwriting">񄡱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00211.html">S162</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00271.html">S1e6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00245.html">S1a6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00189.html">S133</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00233.html">S188</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00007.html">S1fc</a></td>
-<td class="signwriting">񅺡</td>
-<td class="signwriting">񅺑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00030.html">S198</a></td>
+<td class="signwriting col-signwriting-1">񃤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00207.html">S15c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00269.html">S1db</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00167.html">S1cd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00202.html">S14f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00066.html">S18e</a></td>
+<td class="signwriting col-signwriting-1">񃕑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00055.html">S1b0</a></td>
+<td class="signwriting col-signwriting-1">񄈑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00140.html">S18b</a></td>
+<td class="signwriting col-signwriting-1">񃐱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00203.html">S151</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00235.html">S18a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00123.html">S12b</a></td>
+<td class="signwriting col-signwriting-1">񁀱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00260.html">S1c0</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00040.html">S132</a></td>
+<td class="signwriting col-signwriting-1">񁋑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00094.html">S146</a></td>
+<td class="signwriting col-signwriting-1">񁩑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00095.html">S158</a></td>
+<td class="signwriting col-signwriting-1">񂄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00058.html">S112</a></td>
+<td class="signwriting col-signwriting-1">񀛑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00153.html">S1c1</a></td>
+<td class="signwriting col-signwriting-1">񄡱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00211.html">S162</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00271.html">S1e6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00245.html">S1a6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00189.html">S133</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00233.html">S188</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00007.html">S1fc</a></td>
+<td class="signwriting col-signwriting-1">񅺡</td>
+<td class="signwriting col-signwriting-2">񅺑</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00044.html
+++ b/docs/inventories/inv00044.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>NISLs (SP_60)</title>
+  <title>Inventory: NISLs (SP_60)</title>
   
 <style>
 @font-face {
@@ -12,267 +12,489 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>NISLs (SP_60)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00044</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>NISLs (SP_60)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_60</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: NISLs (SP_60)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00044</td>
+<td class="col-language-name">Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00020.html">S1c6</a></td>
-<td class="signwriting">񄩁</td>
-<td class="signwriting">񄩑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00020.html">S1c6</a></td>
+<td class="signwriting col-signwriting-1">񄩁</td>
+<td class="signwriting col-signwriting-2">񄩑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_nonspread</td>
-<td>extended</td>
-<td><a href="../segments/seg00066.html">S18e</a></td>
-<td class="signwriting">񃕑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00066.html">S18e</a></td>
+<td class="signwriting col-signwriting-1">񃕑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00167.html">S1cd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00167.html">S1cd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00055.html">S1b0</a></td>
-<td class="signwriting">񄈑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00055.html">S1b0</a></td>
+<td class="signwriting col-signwriting-1">񄈑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00045.html
+++ b/docs/inventories/inv00045.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ENG (SP_61)</title>
+  <title>Inventory: ENG (SP_61)</title>
   
 <style>
 @font-face {
@@ -12,231 +12,453 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>ENG (SP_61)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00045</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>ENG (SP_61)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Greek Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_61</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: ENG (SP_61)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00045</td>
+<td class="col-language-name">Greek Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00159.html">S1d8</a></td>
-<td class="signwriting">񅄑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00159.html">S1d8</a></td>
+<td class="signwriting col-signwriting-1">񅄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00048.html">S11d</a></td>
-<td class="signwriting">񀫡</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00048.html">S11d</a></td>
+<td class="signwriting col-signwriting-1">񀫡</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00105.html">S1e5</a></td>
-<td class="signwriting">񅗱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00105.html">S1e5</a></td>
+<td class="signwriting col-signwriting-1">񅗱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00160.html">S105</a></td>
-<td class="signwriting">񀇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00160.html">S105</a></td>
+<td class="signwriting col-signwriting-1">񀇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00046.html
+++ b/docs/inventories/inv00046.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Lensegua (SP_112)</title>
+  <title>Inventory: Lensegua (SP_112)</title>
   
 <style>
 @font-face {
@@ -12,96 +12,318 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Lensegua (SP_112)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00046</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>Lensegua (SP_112)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Guatemalan Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_112</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: Lensegua (SP_112)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00046</td>
+<td class="col-language-name">Guatemalan Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00047.html
+++ b/docs/inventories/inv00047.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>HKSL (SP_12)</title>
+  <title>Inventory: HKSL (SP_12)</title>
   
 <style>
 @font-face {
@@ -12,96 +12,318 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>HKSL (SP_12)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00047</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>HKSL (SP_12)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_12</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: HKSL (SP_12)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00047</td>
+<td class="col-language-name">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00048.html
+++ b/docs/inventories/inv00048.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LESHO (SP_16)</title>
+  <title>Inventory: LESHO (SP_16)</title>
   
 <style>
 @font-face {
@@ -12,1284 +12,1506 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LESHO (SP_16)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00048</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LESHO (SP_16)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Honduras Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_16</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LESHO (SP_16)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00048</td>
+<td class="col-language-name">Honduras Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00082.html">S14b</a></td>
-<td class="signwriting">񁰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00142.html">S1a5</a></td>
-<td class="signwriting">񃷱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00157.html">S1d3</a></td>
-<td class="signwriting">񄼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00127.html">S173</a></td>
-<td class="signwriting">񂬱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00227.html">S17b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00062.html">S122</a></td>
-<td class="signwriting">񀳑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00271.html">S1e6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00228.html">S17f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00065.html">S142</a></td>
-<td class="signwriting">񁣑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00224.html">S178</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00203.html">S151</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00221.html">S172</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00209.html">S15f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00088.html">S170</a></td>
-<td class="signwriting">񂨑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00226.html">S17a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00206.html">S15b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00095.html">S158</a></td>
-<td class="signwriting">񂄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00153.html">S1c1</a></td>
-<td class="signwriting">񄡱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00174.html">S10f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00147.html">S1d5</a></td>
-<td class="signwriting">񄿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00105.html">S1e5</a></td>
-<td class="signwriting">񅗱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00233.html">S188</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00215.html">S166</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00164.html">S14d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00222.html">S174</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00179.html">S11b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00085.html">S149</a></td>
-<td class="signwriting">񁭱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00235.html">S18a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00225.html">S179</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00202.html">S14f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00123.html">S12b</a></td>
-<td class="signwriting">񁀱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00086.html">S168</a></td>
-<td class="signwriting">񂜑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00201.html">S148</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00026.html">S1f2</a></td>
-<td class="signwriting">񅫁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>extended</td>
-<td><a href="../segments/seg00071.html">S18f</a></td>
-<td class="signwriting">񃖱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00172.html">S109</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00032.html">S1e2</a></td>
-<td class="signwriting">񅓁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00143.html">S1ba</a></td>
-<td class="signwriting">񄗁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00241.html">S19d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00096.html">S159</a></td>
-<td class="signwriting">񂅱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00199.html">S141</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00278.html">S1fe</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00270.html">S1e3</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00234.html">S189</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00177.html">S114</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00171.html">S107</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00243.html">S1a1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00219.html">S16b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00118.html">S1a3</a></td>
-<td class="signwriting">񃴱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00040.html">S132</a></td>
-<td class="signwriting">񁋑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00272.html">S1e8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00046.html">S116</a></td>
-<td class="signwriting">񀡑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00094.html">S146</a></td>
-<td class="signwriting">񁩑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00082.html">S14b</a></td>
+<td class="signwriting col-signwriting-1">񁰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00142.html">S1a5</a></td>
+<td class="signwriting col-signwriting-1">񃷱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00157.html">S1d3</a></td>
+<td class="signwriting col-signwriting-1">񄼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00127.html">S173</a></td>
+<td class="signwriting col-signwriting-1">񂬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00227.html">S17b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00062.html">S122</a></td>
+<td class="signwriting col-signwriting-1">񀳑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00271.html">S1e6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00228.html">S17f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00065.html">S142</a></td>
+<td class="signwriting col-signwriting-1">񁣑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00224.html">S178</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00203.html">S151</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00221.html">S172</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00209.html">S15f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00088.html">S170</a></td>
+<td class="signwriting col-signwriting-1">񂨑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00226.html">S17a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00206.html">S15b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00095.html">S158</a></td>
+<td class="signwriting col-signwriting-1">񂄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00153.html">S1c1</a></td>
+<td class="signwriting col-signwriting-1">񄡱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00174.html">S10f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00147.html">S1d5</a></td>
+<td class="signwriting col-signwriting-1">񄿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00105.html">S1e5</a></td>
+<td class="signwriting col-signwriting-1">񅗱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00233.html">S188</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00215.html">S166</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00164.html">S14d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00222.html">S174</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00179.html">S11b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00085.html">S149</a></td>
+<td class="signwriting col-signwriting-1">񁭱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00235.html">S18a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00225.html">S179</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00202.html">S14f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00123.html">S12b</a></td>
+<td class="signwriting col-signwriting-1">񁀱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00086.html">S168</a></td>
+<td class="signwriting col-signwriting-1">񂜑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00201.html">S148</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00026.html">S1f2</a></td>
+<td class="signwriting col-signwriting-1">񅫁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00071.html">S18f</a></td>
+<td class="signwriting col-signwriting-1">񃖱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00172.html">S109</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00032.html">S1e2</a></td>
+<td class="signwriting col-signwriting-1">񅓁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00143.html">S1ba</a></td>
+<td class="signwriting col-signwriting-1">񄗁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00241.html">S19d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00096.html">S159</a></td>
+<td class="signwriting col-signwriting-1">񂅱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00199.html">S141</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00278.html">S1fe</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00270.html">S1e3</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00234.html">S189</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00177.html">S114</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00171.html">S107</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00243.html">S1a1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00219.html">S16b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00118.html">S1a3</a></td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00040.html">S132</a></td>
+<td class="signwriting col-signwriting-1">񁋑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00272.html">S1e8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00046.html">S116</a></td>
+<td class="signwriting col-signwriting-1">񀡑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00094.html">S146</a></td>
+<td class="signwriting col-signwriting-1">񁩑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00049.html
+++ b/docs/inventories/inv00049.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LSH (SP_113)</title>
+  <title>Inventory: LSH (SP_113)</title>
   
 <style>
 @font-face {
@@ -12,96 +12,318 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LSH (SP_113)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00049</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LSH (SP_113)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Haitian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_113</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LSH (SP_113)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00049</td>
+<td class="col-language-name">Haitian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00050.html
+++ b/docs/inventories/inv00050.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>HSL (SP_122)</title>
+  <title>Inventory: HSL (SP_122)</title>
   
 <style>
 @font-face {
@@ -12,249 +12,471 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>HSL (SP_122)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00050</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>HSL (SP_122)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Hungarian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_122</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: HSL (SP_122)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00050</td>
+<td class="col-language-name">Hungarian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00214.html">S165</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00214.html">S165</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00219.html">S16b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00219.html">S16b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00087.html">S16e</a></td>
-<td class="signwriting">񂥑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00087.html">S16e</a></td>
+<td class="signwriting col-signwriting-1">񂥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00176.html">S113</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00176.html">S113</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00051.html
+++ b/docs/inventories/inv00051.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ISL (IE) (SP_62)</title>
+  <title>Inventory: ISL (IE) (SP_62)</title>
   
 <style>
 @font-face {
@@ -12,411 +12,633 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>ISL (IE) (SP_62)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00051</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>ISL (IE) (SP_62)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Irish Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_62</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: ISL (IE) (SP_62)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00051</td>
+<td class="col-language-name">Irish Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00142.html">S1a5</a></td>
-<td class="signwriting">񃷱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00142.html">S1a5</a></td>
+<td class="signwriting col-signwriting-1">񃷱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00167.html">S1cd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00167.html">S1cd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00278.html">S1fe</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00278.html">S1fe</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00237.html">S194</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00237.html">S194</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00052.html
+++ b/docs/inventories/inv00052.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Shassi, ISL (SP_110)</title>
+  <title>Inventory: Shassi, ISL (SP_110)</title>
   
 <style>
 @font-face {
@@ -12,258 +12,480 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Shassi, ISL (SP_110)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00052</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>Shassi, ISL (SP_110)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Israeli Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_110</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: Shassi, ISL (SP_110)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00052</td>
+<td class="col-language-name">Israeli Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00007.html">S1fc</a></td>
-<td class="signwriting">񅺡</td>
-<td class="signwriting">񅺑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00007.html">S1fc</a></td>
+<td class="signwriting col-signwriting-1">񅺡</td>
+<td class="signwriting col-signwriting-2">񅺑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00008.html">S1fd</a></td>
-<td class="signwriting">񅼁</td>
-<td class="signwriting">񅻱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00008.html">S1fd</a></td>
+<td class="signwriting col-signwriting-1">񅼁</td>
+<td class="signwriting col-signwriting-2">񅻱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00160.html">S105</a></td>
-<td class="signwriting">񀇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00160.html">S105</a></td>
+<td class="signwriting col-signwriting-1">񀇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00270.html">S1e3</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00270.html">S1e3</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00053.html
+++ b/docs/inventories/inv00053.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ISL (IN) (SP_85)</title>
+  <title>Inventory: ISL (IN) (SP_85)</title>
   
 <style>
 @font-face {
@@ -12,78 +12,300 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>ISL (IN) (SP_85)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00053</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>ISL (IN) (SP_85)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Indian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_85</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: ISL (IN) (SP_85)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00053</td>
+<td class="col-language-name">Indian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00054.html
+++ b/docs/inventories/inv00054.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ÍTM (SP_131)</title>
+  <title>Inventory: ÍTM (SP_131)</title>
   
 <style>
 @font-face {
@@ -12,222 +12,444 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>ÍTM (SP_131)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00054</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>ÍTM (SP_131)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Icelandic Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_131</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: ÍTM (SP_131)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00054</td>
+<td class="col-language-name">Icelandic Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00055.html
+++ b/docs/inventories/inv00055.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LIS (SP_63)</title>
+  <title>Inventory: LIS (SP_63)</title>
   
 <style>
 @font-face {
@@ -12,870 +12,1092 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LIS (SP_63)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00055</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LIS (SP_63)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Italian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_63</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LIS (SP_63)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00055</td>
+<td class="col-language-name">Italian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00223.html">S175</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00228.html">S17f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00058.html">S112</a></td>
-<td class="signwriting">񀛑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00087.html">S16e</a></td>
-<td class="signwriting">񂥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00106.html">S1e7</a></td>
-<td class="signwriting">񅚱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00224.html">S178</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00110.html">S1e4</a></td>
-<td class="signwriting">񅖑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00222.html">S174</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00026.html">S1f2</a></td>
-<td class="signwriting">񅫁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00082.html">S14b</a></td>
-<td class="signwriting">񁰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00256.html">S1bc</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00094.html">S146</a></td>
-<td class="signwriting">񁩑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00164.html">S14d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00159.html">S1d8</a></td>
-<td class="signwriting">񅄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00267.html">S1cf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00261.html">S1c2</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00203.html">S151</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00122.html">S12a</a></td>
-<td class="signwriting">񀿑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00160.html">S105</a></td>
-<td class="signwriting">񀇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00088.html">S170</a></td>
-<td class="signwriting">񂨑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00268.html">S1d9</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00048.html">S11d</a></td>
-<td class="signwriting">񀫡</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00270.html">S1e3</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00167.html">S1cd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00085.html">S149</a></td>
-<td class="signwriting">񁭱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00223.html">S175</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00228.html">S17f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00058.html">S112</a></td>
+<td class="signwriting col-signwriting-1">񀛑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00087.html">S16e</a></td>
+<td class="signwriting col-signwriting-1">񂥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00106.html">S1e7</a></td>
+<td class="signwriting col-signwriting-1">񅚱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00224.html">S178</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00110.html">S1e4</a></td>
+<td class="signwriting col-signwriting-1">񅖑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00222.html">S174</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00026.html">S1f2</a></td>
+<td class="signwriting col-signwriting-1">񅫁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00082.html">S14b</a></td>
+<td class="signwriting col-signwriting-1">񁰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00256.html">S1bc</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00094.html">S146</a></td>
+<td class="signwriting col-signwriting-1">񁩑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00164.html">S14d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00159.html">S1d8</a></td>
+<td class="signwriting col-signwriting-1">񅄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00267.html">S1cf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00261.html">S1c2</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00203.html">S151</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00122.html">S12a</a></td>
+<td class="signwriting col-signwriting-1">񀿑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00160.html">S105</a></td>
+<td class="signwriting col-signwriting-1">񀇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00088.html">S170</a></td>
+<td class="signwriting col-signwriting-1">񂨑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00268.html">S1d9</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00048.html">S11d</a></td>
+<td class="signwriting col-signwriting-1">񀫡</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00270.html">S1e3</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00167.html">S1cd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00085.html">S149</a></td>
+<td class="signwriting col-signwriting-1">񁭱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00056.html
+++ b/docs/inventories/inv00056.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LIU (SP_86)</title>
+  <title>Inventory: LIU (SP_86)</title>
   
 <style>
 @font-face {
@@ -12,204 +12,426 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LIU (SP_86)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00056</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LIU (SP_86)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Jordanian Sign Language or Levantine Arabic Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_86</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LIU (SP_86)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00056</td>
+<td class="col-language-name">Jordanian Sign Language or Levantine Arabic Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00160.html">S105</a></td>
-<td class="signwriting">񀇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00160.html">S105</a></td>
+<td class="signwriting col-signwriting-1">񀇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00264.html">S1c9</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00264.html">S1c9</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00057.html
+++ b/docs/inventories/inv00057.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>JSL (SP_64)</title>
+  <title>Inventory: JSL (SP_64)</title>
   
 <style>
 @font-face {
@@ -12,591 +12,813 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>JSL (SP_64)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00057</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>JSL (SP_64)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Japanese Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_64</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: JSL (SP_64)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00057</td>
+<td class="col-language-name">Japanese Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00020.html">S1c6</a></td>
-<td class="signwriting">񄩁</td>
-<td class="signwriting">񄩑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00020.html">S1c6</a></td>
+<td class="signwriting col-signwriting-1">񄩁</td>
+<td class="signwriting col-signwriting-2">񄩑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00118.html">S1a3</a></td>
-<td class="signwriting">񃴱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00118.html">S1a3</a></td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00120.html">S1b3</a></td>
-<td class="signwriting">񄌱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00120.html">S1b3</a></td>
+<td class="signwriting col-signwriting-1">񄌱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00161.html">S196</a></td>
-<td class="signwriting">񃡑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00161.html">S196</a></td>
+<td class="signwriting col-signwriting-1">񃡑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00215.html">S166</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00215.html">S166</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00228.html">S17f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00228.html">S17f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00110.html">S1e4</a></td>
-<td class="signwriting">񅖑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00110.html">S1e4</a></td>
+<td class="signwriting col-signwriting-1">񅖑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00030.html">S198</a></td>
-<td class="signwriting">񃤑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00030.html">S198</a></td>
+<td class="signwriting col-signwriting-1">񃤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_nonspread</td>
-<td>extended</td>
-<td><a href="../segments/seg00066.html">S18e</a></td>
-<td class="signwriting">񃕑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00066.html">S18e</a></td>
+<td class="signwriting col-signwriting-1">񃕑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00267.html">S1cf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00267.html">S1cf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00058.html
+++ b/docs/inventories/inv00058.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>KSL, LAK (SP_79)</title>
+  <title>Inventory: KSL, LAK (SP_79)</title>
   
 <style>
 @font-face {
@@ -12,159 +12,381 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>KSL, LAK (SP_79)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00058</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>KSL, LAK (SP_79)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Kenya-Somali Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_79</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: KSL, LAK (SP_79)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00058</td>
+<td class="col-language-name">Kenya-Somali Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00159.html">S1d8</a></td>
-<td class="signwriting">񅄑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00159.html">S1d8</a></td>
+<td class="signwriting col-signwriting-1">񅄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00065.html">S142</a></td>
-<td class="signwriting">񁣑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00065.html">S142</a></td>
+<td class="signwriting col-signwriting-1">񁣑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00059.html
+++ b/docs/inventories/inv00059.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>KSL (SP_78)</title>
+  <title>Inventory: KSL (SP_78)</title>
   
 <style>
 @font-face {
@@ -12,1995 +12,2217 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>KSL (SP_78)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00059</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>KSL (SP_78)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Korean Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_78</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: KSL (SP_78)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00059</td>
+<td class="col-language-name">Korean Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00046.html">S116</a></td>
-<td class="signwriting">񀡑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00228.html">S17f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00087.html">S16e</a></td>
-<td class="signwriting">񂥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00202.html">S14f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00172.html">S109</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00224.html">S178</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00221.html">S172</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00203.html">S151</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00009.html">S1ff</a></td>
-<td class="signwriting">񅾱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00175.html">S111</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00164.html">S14d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00110.html">S1e4</a></td>
-<td class="signwriting">񅖑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00030.html">S198</a></td>
-<td class="signwriting">񃤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00227.html">S17b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00153.html">S1c1</a></td>
-<td class="signwriting">񄡱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00095.html">S158</a></td>
-<td class="signwriting">񂄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00140.html">S18b</a></td>
-<td class="signwriting">񃐱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00271.html">S1e6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00222.html">S174</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00226.html">S17a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00061.html">S121</a></td>
-<td class="signwriting">񀱱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00143.html">S1ba</a></td>
-<td class="signwriting">񄗁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00088.html">S170</a></td>
-<td class="signwriting">񂨑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00106.html">S1e7</a></td>
-<td class="signwriting">񅚱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00216.html">S167</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00127.html">S173</a></td>
-<td class="signwriting">񂬱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00243.html">S1a1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00270.html">S1e3</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00094.html">S146</a></td>
-<td class="signwriting">񁩑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00264.html">S1c9</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00269.html">S1db</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00188.html">S131</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00141.html">S1a4</a></td>
-<td class="signwriting">񃶁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_nonspread</td>
-<td>extended</td>
-<td><a href="../segments/seg00066.html">S18e</a></td>
-<td class="signwriting">񃕑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00191.html">S135</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00260.html">S1c0</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00142.html">S1a5</a></td>
-<td class="signwriting">񃷱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00062.html">S122</a></td>
-<td class="signwriting">񀳑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00225.html">S179</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00123.html">S12b</a></td>
-<td class="signwriting">񁀱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00032.html">S1e2</a></td>
-<td class="signwriting">񅓁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00118.html">S1a3</a></td>
-<td class="signwriting">񃴱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00254.html">S1b8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00241.html">S19d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00209.html">S15f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00189.html">S133</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00122.html">S12a</a></td>
-<td class="signwriting">񀿑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00040.html">S132</a></td>
-<td class="signwriting">񁋑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00058.html">S112</a></td>
-<td class="signwriting">񀛑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00120.html">S1b3</a></td>
-<td class="signwriting">񄌱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00105.html">S1e5</a></td>
-<td class="signwriting">񅗱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00215.html">S166</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00086.html">S168</a></td>
-<td class="signwriting">񂜑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00082.html">S14b</a></td>
-<td class="signwriting">񁰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00217.html">S169</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00237.html">S194</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00026.html">S1f2</a></td>
-<td class="signwriting">񅫁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00240.html">S19b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00059.html">S123</a></td>
-<td class="signwriting">񀴱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00167.html">S1cd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00124.html">S127</a></td>
-<td class="signwriting">񀺱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00174.html">S10f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00238.html">S195</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00176.html">S113</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00272.html">S1e8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00091.html">S1d7</a></td>
-<td class="signwriting">񅂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00161.html">S196</a></td>
-<td class="signwriting">񃡑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00223.html">S175</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00190.html">S134</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00096.html">S159</a></td>
-<td class="signwriting">񂅱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00267.html">S1cf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00230.html">S183</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00023.html">S1df</a></td>
-<td class="signwriting">񅎱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00276.html">S1f6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00178.html">S117</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00020.html">S1c6</a></td>
-<td class="signwriting">񄩁</td>
-<td class="signwriting">񄩑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00017.html">S193</a></td>
-<td class="signwriting">񃜱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00171.html">S107</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00208.html">S15e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00065.html">S142</a></td>
-<td class="signwriting">񁣑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00210.html">S161</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00119.html">S1b2</a></td>
-<td class="signwriting">񄋑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00235.html">S18a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>extended</td>
-<td><a href="../segments/seg00071.html">S18f</a></td>
-<td class="signwriting">񃖱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00038.html">S1b5</a></td>
-<td class="signwriting">񄏱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00085.html">S149</a></td>
-<td class="signwriting">񁭱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00181.html">S11f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00184.html">S12c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00278.html">S1fe</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00148.html">S1d6</a></td>
-<td class="signwriting">񅁑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00206.html">S15b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00169.html">S102</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00183.html">S124</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00244.html">S1a2</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00234.html">S189</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00027.html">S1f3</a></td>
-<td class="signwriting">񅬱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00218.html">S16a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00102.html">S1a7</a></td>
-<td class="signwriting">񃺱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00147.html">S1d5</a></td>
-<td class="signwriting">񄿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00041.html">S13e</a></td>
-<td class="signwriting">񁝑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00219.html">S16b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00245.html">S1a6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00239.html">S197</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00055.html">S1b0</a></td>
-<td class="signwriting">񄈑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00063.html">S126</a></td>
-<td class="signwriting">񀹑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00014.html">S103</a></td>
-<td class="signwriting">񀄱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00179.html">S11b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00109.html">S19f</a></td>
-<td class="signwriting">񃮱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00251.html">S1b1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00214.html">S165</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00236.html">S191</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00256.html">S1bc</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00177.html">S114</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00250.html">S1af</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00252.html">S1b6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00048.html">S11d</a></td>
-<td class="signwriting">񀫡</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00173.html">S10d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00259.html">S1bf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00263.html">S1c8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00266.html">S1cc</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00207.html">S15c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00246.html">S1a8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00186.html">S12f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00104.html">S199</a></td>
-<td class="signwriting">񃥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00231.html">S184</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00193.html">S137</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00196.html">S13a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00057.html">S1cb</a></td>
-<td class="signwriting">񄰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00257.html">S1bd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00185.html">S12e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00007.html">S1fc</a></td>
-<td class="signwriting">񅺡</td>
-<td class="signwriting">񅺑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00253.html">S1b7</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00046.html">S116</a></td>
+<td class="signwriting col-signwriting-1">񀡑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00228.html">S17f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00087.html">S16e</a></td>
+<td class="signwriting col-signwriting-1">񂥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00202.html">S14f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00172.html">S109</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00224.html">S178</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00221.html">S172</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00203.html">S151</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00009.html">S1ff</a></td>
+<td class="signwriting col-signwriting-1">񅾱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00175.html">S111</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00164.html">S14d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00110.html">S1e4</a></td>
+<td class="signwriting col-signwriting-1">񅖑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00030.html">S198</a></td>
+<td class="signwriting col-signwriting-1">񃤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00227.html">S17b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00153.html">S1c1</a></td>
+<td class="signwriting col-signwriting-1">񄡱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00095.html">S158</a></td>
+<td class="signwriting col-signwriting-1">񂄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00140.html">S18b</a></td>
+<td class="signwriting col-signwriting-1">񃐱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00271.html">S1e6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00222.html">S174</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00226.html">S17a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00061.html">S121</a></td>
+<td class="signwriting col-signwriting-1">񀱱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00143.html">S1ba</a></td>
+<td class="signwriting col-signwriting-1">񄗁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00088.html">S170</a></td>
+<td class="signwriting col-signwriting-1">񂨑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00106.html">S1e7</a></td>
+<td class="signwriting col-signwriting-1">񅚱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00216.html">S167</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00127.html">S173</a></td>
+<td class="signwriting col-signwriting-1">񂬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00243.html">S1a1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00270.html">S1e3</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00094.html">S146</a></td>
+<td class="signwriting col-signwriting-1">񁩑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00264.html">S1c9</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00269.html">S1db</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00188.html">S131</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00141.html">S1a4</a></td>
+<td class="signwriting col-signwriting-1">񃶁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00066.html">S18e</a></td>
+<td class="signwriting col-signwriting-1">񃕑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00191.html">S135</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00260.html">S1c0</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00142.html">S1a5</a></td>
+<td class="signwriting col-signwriting-1">񃷱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00062.html">S122</a></td>
+<td class="signwriting col-signwriting-1">񀳑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00225.html">S179</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00123.html">S12b</a></td>
+<td class="signwriting col-signwriting-1">񁀱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00032.html">S1e2</a></td>
+<td class="signwriting col-signwriting-1">񅓁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00118.html">S1a3</a></td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00254.html">S1b8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00241.html">S19d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00209.html">S15f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00189.html">S133</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00122.html">S12a</a></td>
+<td class="signwriting col-signwriting-1">񀿑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00040.html">S132</a></td>
+<td class="signwriting col-signwriting-1">񁋑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00058.html">S112</a></td>
+<td class="signwriting col-signwriting-1">񀛑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00120.html">S1b3</a></td>
+<td class="signwriting col-signwriting-1">񄌱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00105.html">S1e5</a></td>
+<td class="signwriting col-signwriting-1">񅗱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00215.html">S166</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00086.html">S168</a></td>
+<td class="signwriting col-signwriting-1">񂜑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00082.html">S14b</a></td>
+<td class="signwriting col-signwriting-1">񁰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00217.html">S169</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00237.html">S194</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00026.html">S1f2</a></td>
+<td class="signwriting col-signwriting-1">񅫁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00240.html">S19b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00059.html">S123</a></td>
+<td class="signwriting col-signwriting-1">񀴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00167.html">S1cd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00124.html">S127</a></td>
+<td class="signwriting col-signwriting-1">񀺱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00174.html">S10f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00238.html">S195</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00176.html">S113</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00272.html">S1e8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00091.html">S1d7</a></td>
+<td class="signwriting col-signwriting-1">񅂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00161.html">S196</a></td>
+<td class="signwriting col-signwriting-1">񃡑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00223.html">S175</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00190.html">S134</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00096.html">S159</a></td>
+<td class="signwriting col-signwriting-1">񂅱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00267.html">S1cf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00230.html">S183</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00023.html">S1df</a></td>
+<td class="signwriting col-signwriting-1">񅎱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00276.html">S1f6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00178.html">S117</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00020.html">S1c6</a></td>
+<td class="signwriting col-signwriting-1">񄩁</td>
+<td class="signwriting col-signwriting-2">񄩑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00017.html">S193</a></td>
+<td class="signwriting col-signwriting-1">񃜱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00171.html">S107</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00208.html">S15e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00065.html">S142</a></td>
+<td class="signwriting col-signwriting-1">񁣑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00210.html">S161</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00119.html">S1b2</a></td>
+<td class="signwriting col-signwriting-1">񄋑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00235.html">S18a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00071.html">S18f</a></td>
+<td class="signwriting col-signwriting-1">񃖱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00038.html">S1b5</a></td>
+<td class="signwriting col-signwriting-1">񄏱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00085.html">S149</a></td>
+<td class="signwriting col-signwriting-1">񁭱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00181.html">S11f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00184.html">S12c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00278.html">S1fe</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00148.html">S1d6</a></td>
+<td class="signwriting col-signwriting-1">񅁑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00206.html">S15b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00169.html">S102</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00183.html">S124</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00244.html">S1a2</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00234.html">S189</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00027.html">S1f3</a></td>
+<td class="signwriting col-signwriting-1">񅬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00218.html">S16a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00102.html">S1a7</a></td>
+<td class="signwriting col-signwriting-1">񃺱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00147.html">S1d5</a></td>
+<td class="signwriting col-signwriting-1">񄿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00041.html">S13e</a></td>
+<td class="signwriting col-signwriting-1">񁝑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00219.html">S16b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00245.html">S1a6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00239.html">S197</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00055.html">S1b0</a></td>
+<td class="signwriting col-signwriting-1">񄈑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00063.html">S126</a></td>
+<td class="signwriting col-signwriting-1">񀹑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00014.html">S103</a></td>
+<td class="signwriting col-signwriting-1">񀄱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00179.html">S11b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00109.html">S19f</a></td>
+<td class="signwriting col-signwriting-1">񃮱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00251.html">S1b1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00214.html">S165</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00236.html">S191</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00256.html">S1bc</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00177.html">S114</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00250.html">S1af</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00252.html">S1b6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00048.html">S11d</a></td>
+<td class="signwriting col-signwriting-1">񀫡</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00173.html">S10d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00259.html">S1bf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00263.html">S1c8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00266.html">S1cc</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00207.html">S15c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00246.html">S1a8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00186.html">S12f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00104.html">S199</a></td>
+<td class="signwriting col-signwriting-1">񃥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00231.html">S184</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00193.html">S137</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00196.html">S13a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00057.html">S1cb</a></td>
+<td class="signwriting col-signwriting-1">񄰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00257.html">S1bd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00185.html">S12e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00007.html">S1fc</a></td>
+<td class="signwriting col-signwriting-1">񅺡</td>
+<td class="signwriting col-signwriting-2">񅺑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00253.html">S1b7</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00060.html
+++ b/docs/inventories/inv00060.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LGK (SP_107)</title>
+  <title>Inventory: LGK (SP_107)</title>
   
 <style>
 @font-face {
@@ -12,96 +12,318 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LGK (SP_107)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00060</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LGK (SP_107)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Lithuanian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_107</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LGK (SP_107)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00060</td>
+<td class="col-language-name">Lithuanian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00061.html
+++ b/docs/inventories/inv00061.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LSL (SP_108)</title>
+  <title>Inventory: LSL (SP_108)</title>
   
 <style>
 @font-face {
@@ -12,96 +12,318 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LSL (SP_108)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00061</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LSL (SP_108)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Latvian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_108</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LSL (SP_108)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00061</td>
+<td class="col-language-name">Latvian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00062.html
+++ b/docs/inventories/inv00062.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LSM (MT) (SP_31)</title>
+  <title>Inventory: LSM (MT) (SP_31)</title>
   
 <style>
 @font-face {
@@ -12,1239 +12,1461 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LSM (MT) (SP_31)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00062</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LSM (MT) (SP_31)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Maltese Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_31</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LSM (MT) (SP_31)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00062</td>
+<td class="col-language-name">Maltese Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00026.html">S1f2</a></td>
-<td class="signwriting">񅫁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00222.html">S174</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00227.html">S17b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00228.html">S17f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00159.html">S1d8</a></td>
-<td class="signwriting">񅄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00122.html">S12a</a></td>
-<td class="signwriting">񀿑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_nonspread</td>
-<td>extended</td>
-<td><a href="../segments/seg00066.html">S18e</a></td>
-<td class="signwriting">񃕑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00202.html">S14f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00223.html">S175</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00118.html">S1a3</a></td>
-<td class="signwriting">񃴱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00082.html">S14b</a></td>
-<td class="signwriting">񁰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00014.html">S103</a></td>
-<td class="signwriting">񀄱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00241.html">S19d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00147.html">S1d5</a></td>
-<td class="signwriting">񄿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00230.html">S183</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00127.html">S173</a></td>
-<td class="signwriting">񂬱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00164.html">S14d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00271.html">S1e6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00032.html">S1e2</a></td>
-<td class="signwriting">񅓁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00181.html">S11f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00210.html">S161</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00272.html">S1e8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00189.html">S133</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00102.html">S1a7</a></td>
-<td class="signwriting">񃺱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00160.html">S105</a></td>
-<td class="signwriting">񀇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00027.html">S1f3</a></td>
-<td class="signwriting">񅬱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00219.html">S16b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00041.html">S13e</a></td>
-<td class="signwriting">񁝑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00140.html">S18b</a></td>
-<td class="signwriting">񃐱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00179.html">S11b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00120.html">S1b3</a></td>
-<td class="signwriting">񄌱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00171.html">S107</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00276.html">S1f6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00017.html">S193</a></td>
-<td class="signwriting">񃜱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00157.html">S1d3</a></td>
-<td class="signwriting">񄼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>extended</td>
-<td><a href="../segments/seg00071.html">S18f</a></td>
-<td class="signwriting">񃖱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00203.html">S151</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00169.html">S102</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00215.html">S166</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00226.html">S17a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00105.html">S1e5</a></td>
-<td class="signwriting">񅗱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00209.html">S15f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00170.html">S104</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00062.html">S122</a></td>
-<td class="signwriting">񀳑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00269.html">S1db</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00095.html">S158</a></td>
-<td class="signwriting">񂄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00106.html">S1e7</a></td>
-<td class="signwriting">񅚱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00143.html">S1ba</a></td>
-<td class="signwriting">񄗁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00221.html">S172</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00225.html">S179</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00234.html">S189</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00026.html">S1f2</a></td>
+<td class="signwriting col-signwriting-1">񅫁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00222.html">S174</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00227.html">S17b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00228.html">S17f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00159.html">S1d8</a></td>
+<td class="signwriting col-signwriting-1">񅄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00122.html">S12a</a></td>
+<td class="signwriting col-signwriting-1">񀿑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00066.html">S18e</a></td>
+<td class="signwriting col-signwriting-1">񃕑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00202.html">S14f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00223.html">S175</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00118.html">S1a3</a></td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00082.html">S14b</a></td>
+<td class="signwriting col-signwriting-1">񁰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00014.html">S103</a></td>
+<td class="signwriting col-signwriting-1">񀄱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00241.html">S19d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00147.html">S1d5</a></td>
+<td class="signwriting col-signwriting-1">񄿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00230.html">S183</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00127.html">S173</a></td>
+<td class="signwriting col-signwriting-1">񂬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00164.html">S14d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00271.html">S1e6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00032.html">S1e2</a></td>
+<td class="signwriting col-signwriting-1">񅓁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00181.html">S11f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00210.html">S161</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00272.html">S1e8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00189.html">S133</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00102.html">S1a7</a></td>
+<td class="signwriting col-signwriting-1">񃺱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00160.html">S105</a></td>
+<td class="signwriting col-signwriting-1">񀇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00027.html">S1f3</a></td>
+<td class="signwriting col-signwriting-1">񅬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00219.html">S16b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00041.html">S13e</a></td>
+<td class="signwriting col-signwriting-1">񁝑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00140.html">S18b</a></td>
+<td class="signwriting col-signwriting-1">񃐱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00179.html">S11b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00120.html">S1b3</a></td>
+<td class="signwriting col-signwriting-1">񄌱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00171.html">S107</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00276.html">S1f6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00017.html">S193</a></td>
+<td class="signwriting col-signwriting-1">񃜱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00157.html">S1d3</a></td>
+<td class="signwriting col-signwriting-1">񄼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00071.html">S18f</a></td>
+<td class="signwriting col-signwriting-1">񃖱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00203.html">S151</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00169.html">S102</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00215.html">S166</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00226.html">S17a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00105.html">S1e5</a></td>
+<td class="signwriting col-signwriting-1">񅗱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00209.html">S15f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00170.html">S104</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00062.html">S122</a></td>
+<td class="signwriting col-signwriting-1">񀳑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00269.html">S1db</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00095.html">S158</a></td>
+<td class="signwriting col-signwriting-1">񂄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00106.html">S1e7</a></td>
+<td class="signwriting col-signwriting-1">񅚱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00143.html">S1ba</a></td>
+<td class="signwriting col-signwriting-1">񄗁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00221.html">S172</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00225.html">S179</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00234.html">S189</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00063.html
+++ b/docs/inventories/inv00063.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>MSL (SP_128)</title>
+  <title>Inventory: MSL (SP_128)</title>
   
 <style>
 @font-face {
@@ -12,348 +12,570 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>MSL (SP_128)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00063</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>MSL (SP_128)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Malawian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_128</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: MSL (SP_128)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00063</td>
+<td class="col-language-name">Malawian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00176.html">S113</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00176.html">S113</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00048.html">S11d</a></td>
-<td class="signwriting">񀫡</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00048.html">S11d</a></td>
+<td class="signwriting col-signwriting-1">񀫡</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00058.html">S112</a></td>
-<td class="signwriting">񀛑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00058.html">S112</a></td>
+<td class="signwriting col-signwriting-1">񀛑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00206.html">S15b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00206.html">S15b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00179.html">S11b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00179.html">S11b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00199.html">S141</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00199.html">S141</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00064.html
+++ b/docs/inventories/inv00064.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LSM (MX) (SP_65)</title>
+  <title>Inventory: LSM (MX) (SP_65)</title>
   
 <style>
 @font-face {
@@ -12,1167 +12,1389 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LSM (MX) (SP_65)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00064</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LSM (MX) (SP_65)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Mexican Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_65</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LSM (MX) (SP_65)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00064</td>
+<td class="col-language-name">Mexican Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00159.html">S1d8</a></td>
-<td class="signwriting">񅄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00268.html">S1d9</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00065.html">S142</a></td>
-<td class="signwriting">񁣑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00189.html">S133</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00194.html">S138</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00102.html">S1a7</a></td>
-<td class="signwriting">񃺱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00260.html">S1c0</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00062.html">S122</a></td>
-<td class="signwriting">񀳑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00058.html">S112</a></td>
-<td class="signwriting">񀛑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00212.html">S163</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00014.html">S103</a></td>
-<td class="signwriting">񀄱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00241.html">S19d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00271.html">S1e6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00190.html">S134</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00172.html">S109</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00207.html">S15c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00019.html">S1ae</a></td>
-<td class="signwriting">񄅑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00192.html">S136</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00124.html">S127</a></td>
-<td class="signwriting">񀺱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00118.html">S1a3</a></td>
-<td class="signwriting">񃴱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00228.html">S17f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00211.html">S162</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00215.html">S166</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00120.html">S1b3</a></td>
-<td class="signwriting">񄌱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00261.html">S1c2</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00030.html">S198</a></td>
-<td class="signwriting">񃤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00253.html">S1b7</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00244.html">S1a2</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00216.html">S167</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00048.html">S11d</a></td>
-<td class="signwriting">񀫡</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00140.html">S18b</a></td>
-<td class="signwriting">񃐱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00153.html">S1c1</a></td>
-<td class="signwriting">񄡱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00224.html">S178</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00255.html">S1b9</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00094.html">S146</a></td>
-<td class="signwriting">񁩑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_nonspread</td>
-<td>extended</td>
-<td><a href="../segments/seg00066.html">S18e</a></td>
-<td class="signwriting">񃕑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00257.html">S1bd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00179.html">S11b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00032.html">S1e2</a></td>
-<td class="signwriting">񅓁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00191.html">S135</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00167.html">S1cd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00246.html">S1a8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00174.html">S10f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00159.html">S1d8</a></td>
+<td class="signwriting col-signwriting-1">񅄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00268.html">S1d9</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00065.html">S142</a></td>
+<td class="signwriting col-signwriting-1">񁣑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00189.html">S133</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00194.html">S138</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00102.html">S1a7</a></td>
+<td class="signwriting col-signwriting-1">񃺱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00260.html">S1c0</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00062.html">S122</a></td>
+<td class="signwriting col-signwriting-1">񀳑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00058.html">S112</a></td>
+<td class="signwriting col-signwriting-1">񀛑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00212.html">S163</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00014.html">S103</a></td>
+<td class="signwriting col-signwriting-1">񀄱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00241.html">S19d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00271.html">S1e6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00190.html">S134</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00172.html">S109</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00207.html">S15c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00019.html">S1ae</a></td>
+<td class="signwriting col-signwriting-1">񄅑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00192.html">S136</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00124.html">S127</a></td>
+<td class="signwriting col-signwriting-1">񀺱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00118.html">S1a3</a></td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00228.html">S17f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00211.html">S162</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00215.html">S166</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00120.html">S1b3</a></td>
+<td class="signwriting col-signwriting-1">񄌱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00261.html">S1c2</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00030.html">S198</a></td>
+<td class="signwriting col-signwriting-1">񃤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00253.html">S1b7</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00244.html">S1a2</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00216.html">S167</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00048.html">S11d</a></td>
+<td class="signwriting col-signwriting-1">񀫡</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00140.html">S18b</a></td>
+<td class="signwriting col-signwriting-1">񃐱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00153.html">S1c1</a></td>
+<td class="signwriting col-signwriting-1">񄡱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00224.html">S178</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00255.html">S1b9</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00094.html">S146</a></td>
+<td class="signwriting col-signwriting-1">񁩑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00066.html">S18e</a></td>
+<td class="signwriting col-signwriting-1">񃕑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00257.html">S1bd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00179.html">S11b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00032.html">S1e2</a></td>
+<td class="signwriting col-signwriting-1">񅓁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00191.html">S135</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00167.html">S1cd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00246.html">S1a8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00174.html">S10f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00065.html
+++ b/docs/inventories/inv00065.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>BIM (SP_66)</title>
+  <title>Inventory: BIM (SP_66)</title>
   
 <style>
 @font-face {
@@ -12,87 +12,309 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>BIM (SP_66)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00065</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>BIM (SP_66)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Malaysian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_66</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: BIM (SP_66)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00065</td>
+<td class="col-language-name">Malaysian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00066.html
+++ b/docs/inventories/inv00066.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>NSL (NG) (SP_32)</title>
+  <title>Inventory: NSL (NG) (SP_32)</title>
   
 <style>
 @font-face {
@@ -12,123 +12,345 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>NSL (NG) (SP_32)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00066</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>NSL (NG) (SP_32)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Nigerian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_32</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: NSL (NG) (SP_32)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00066</td>
+<td class="col-language-name">Nigerian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00067.html
+++ b/docs/inventories/inv00067.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ISN (SP_67)</title>
+  <title>Inventory: ISN (SP_67)</title>
   
 <style>
 @font-face {
@@ -12,861 +12,1083 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>ISN (SP_67)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00067</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>ISN (SP_67)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Nicaraguan Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_67</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: ISN (SP_67)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00067</td>
+<td class="col-language-name">Nicaraguan Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00065.html">S142</a></td>
-<td class="signwriting">񁣑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00024.html">S1e0</a></td>
-<td class="signwriting">񅐁</td>
-<td class="signwriting">񅐑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00223.html">S175</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00215.html">S166</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>extended</td>
-<td><a href="../segments/seg00074.html">S1c4</a></td>
-<td class="signwriting">񄦑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00216.html">S167</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00062.html">S122</a></td>
-<td class="signwriting">񀳑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00209.html">S15f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00243.html">S1a1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_nonspread</td>
-<td>extended</td>
-<td><a href="../segments/seg00066.html">S18e</a></td>
-<td class="signwriting">񃕑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00240.html">S19b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00110.html">S1e4</a></td>
-<td class="signwriting">񅖑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00055.html">S1b0</a></td>
-<td class="signwriting">񄈑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00267.html">S1cf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00091.html">S1d7</a></td>
-<td class="signwriting">񅂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00142.html">S1a5</a></td>
-<td class="signwriting">񃷱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00256.html">S1bc</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00153.html">S1c1</a></td>
-<td class="signwriting">񄡱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00105.html">S1e5</a></td>
-<td class="signwriting">񅗱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00065.html">S142</a></td>
+<td class="signwriting col-signwriting-1">񁣑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00024.html">S1e0</a></td>
+<td class="signwriting col-signwriting-1">񅐁</td>
+<td class="signwriting col-signwriting-2">񅐑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00223.html">S175</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00215.html">S166</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00074.html">S1c4</a></td>
+<td class="signwriting col-signwriting-1">񄦑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00216.html">S167</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00062.html">S122</a></td>
+<td class="signwriting col-signwriting-1">񀳑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00209.html">S15f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00243.html">S1a1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00066.html">S18e</a></td>
+<td class="signwriting col-signwriting-1">񃕑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00240.html">S19b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00110.html">S1e4</a></td>
+<td class="signwriting col-signwriting-1">񅖑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00055.html">S1b0</a></td>
+<td class="signwriting col-signwriting-1">񄈑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00267.html">S1cf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00091.html">S1d7</a></td>
+<td class="signwriting col-signwriting-1">񅂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00142.html">S1a5</a></td>
+<td class="signwriting col-signwriting-1">񃷱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00256.html">S1bc</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00153.html">S1c1</a></td>
+<td class="signwriting col-signwriting-1">񄡱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00105.html">S1e5</a></td>
+<td class="signwriting col-signwriting-1">񅗱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00068.html
+++ b/docs/inventories/inv00068.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>NGT, SLN (SP_68)</title>
+  <title>Inventory: NGT, SLN (SP_68)</title>
   
 <style>
 @font-face {
@@ -12,384 +12,606 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>NGT, SLN (SP_68)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00068</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>NGT, SLN (SP_68)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_68</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: NGT, SLN (SP_68)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00068</td>
+<td class="col-language-name">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_nonspread</td>
-<td>extended</td>
-<td><a href="../segments/seg00066.html">S18e</a></td>
-<td class="signwriting">񃕑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00066.html">S18e</a></td>
+<td class="signwriting col-signwriting-1">񃕑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00069.html
+++ b/docs/inventories/inv00069.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>NTS, NSL (SP_69)</title>
+  <title>Inventory: NTS, NSL (SP_69)</title>
   
 <style>
 @font-face {
@@ -12,1077 +12,1299 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>NTS, NSL (SP_69)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00069</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>NTS, NSL (SP_69)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Norwegian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_69</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: NTS, NSL (SP_69)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00069</td>
+<td class="col-language-name">Norwegian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00207.html">S15c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00147.html">S1d5</a></td>
-<td class="signwriting">񄿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00206.html">S15b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00164.html">S14d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_nonspread</td>
-<td>extended</td>
-<td><a href="../segments/seg00066.html">S18e</a></td>
-<td class="signwriting">񃕑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00065.html">S142</a></td>
-<td class="signwriting">񁣑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00062.html">S122</a></td>
-<td class="signwriting">񀳑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00026.html">S1f2</a></td>
-<td class="signwriting">񅫁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00030.html">S198</a></td>
-<td class="signwriting">񃤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00159.html">S1d8</a></td>
-<td class="signwriting">񅄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00023.html">S1df</a></td>
-<td class="signwriting">񅎱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00215.html">S166</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00140.html">S18b</a></td>
-<td class="signwriting">񃐱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00209.html">S15f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00160.html">S105</a></td>
-<td class="signwriting">񀇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00216.html">S167</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00228.html">S17f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00148.html">S1d6</a></td>
-<td class="signwriting">񅁑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00230.html">S183</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00268.html">S1d9</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00183.html">S124</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00221.html">S172</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00240.html">S19b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00262.html">S1c7</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00027.html">S1f3</a></td>
-<td class="signwriting">񅬱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00032.html">S1e2</a></td>
-<td class="signwriting">񅓁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00161.html">S196</a></td>
-<td class="signwriting">񃡑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00109.html">S19f</a></td>
-<td class="signwriting">񃮱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00172.html">S109</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00094.html">S146</a></td>
-<td class="signwriting">񁩑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00176.html">S113</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00261.html">S1c2</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00168.html">S1dd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00276.html">S1f6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00207.html">S15c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00147.html">S1d5</a></td>
+<td class="signwriting col-signwriting-1">񄿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00206.html">S15b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00164.html">S14d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00066.html">S18e</a></td>
+<td class="signwriting col-signwriting-1">񃕑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00065.html">S142</a></td>
+<td class="signwriting col-signwriting-1">񁣑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00062.html">S122</a></td>
+<td class="signwriting col-signwriting-1">񀳑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00026.html">S1f2</a></td>
+<td class="signwriting col-signwriting-1">񅫁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00030.html">S198</a></td>
+<td class="signwriting col-signwriting-1">񃤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00159.html">S1d8</a></td>
+<td class="signwriting col-signwriting-1">񅄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00023.html">S1df</a></td>
+<td class="signwriting col-signwriting-1">񅎱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00215.html">S166</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00140.html">S18b</a></td>
+<td class="signwriting col-signwriting-1">񃐱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00209.html">S15f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00160.html">S105</a></td>
+<td class="signwriting col-signwriting-1">񀇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00216.html">S167</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00228.html">S17f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00148.html">S1d6</a></td>
+<td class="signwriting col-signwriting-1">񅁑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00230.html">S183</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00268.html">S1d9</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00183.html">S124</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00221.html">S172</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00240.html">S19b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00262.html">S1c7</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00027.html">S1f3</a></td>
+<td class="signwriting col-signwriting-1">񅬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00032.html">S1e2</a></td>
+<td class="signwriting col-signwriting-1">񅓁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00161.html">S196</a></td>
+<td class="signwriting col-signwriting-1">񃡑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00109.html">S19f</a></td>
+<td class="signwriting col-signwriting-1">񃮱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00172.html">S109</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00094.html">S146</a></td>
+<td class="signwriting col-signwriting-1">񁩑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00176.html">S113</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00261.html">S1c2</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00168.html">S1dd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00276.html">S1f6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00070.html
+++ b/docs/inventories/inv00070.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>NSL (NP) (SP_133)</title>
+  <title>Inventory: NSL (NP) (SP_133)</title>
   
 <style>
 @font-face {
@@ -12,114 +12,336 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>NSL (NP) (SP_133)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00070</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>NSL (NP) (SP_133)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Nepalese Sign Language or Nepali Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_133</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: NSL (NP) (SP_133)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00070</td>
+<td class="col-language-name">Nepalese Sign Language or Nepali Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00071.html
+++ b/docs/inventories/inv00071.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>NZSL (SP_70)</title>
+  <title>Inventory: NZSL (SP_70)</title>
   
 <style>
 @font-face {
@@ -12,195 +12,417 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>NZSL (SP_70)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00071</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>NZSL (SP_70)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>New Zealand Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_70</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: NZSL (SP_70)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00071</td>
+<td class="col-language-name">New Zealand Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00030.html">S198</a></td>
-<td class="signwriting">񃤑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00030.html">S198</a></td>
+<td class="signwriting col-signwriting-1">񃤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00072.html
+++ b/docs/inventories/inv00072.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LSP (SP_71)</title>
+  <title>Inventory: LSP (SP_71)</title>
   
 <style>
 @font-face {
@@ -12,456 +12,678 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LSP (SP_71)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00072</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LSP (SP_71)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Peruvian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_71</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LSP (SP_71)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00072</td>
+<td class="col-language-name">Peruvian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00118.html">S1a3</a></td>
-<td class="signwriting">񃴱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00118.html">S1a3</a></td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00142.html">S1a5</a></td>
-<td class="signwriting">񃷱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00142.html">S1a5</a></td>
+<td class="signwriting col-signwriting-1">񃷱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00167.html">S1cd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00167.html">S1cd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00254.html">S1b8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00254.html">S1b8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00073.html
+++ b/docs/inventories/inv00073.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>FSL (SP_72)</title>
+  <title>Inventory: FSL (SP_72)</title>
   
 <style>
 @font-face {
@@ -12,834 +12,1056 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>FSL (SP_72)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00073</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>FSL (SP_72)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Philippine Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_72</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: FSL (SP_72)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00073</td>
+<td class="col-language-name">Philippine Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00278.html">S1fe</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00206.html">S15b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00095.html">S158</a></td>
-<td class="signwriting">񂄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00082.html">S14b</a></td>
-<td class="signwriting">񁰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00058.html">S112</a></td>
-<td class="signwriting">񀛑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00085.html">S149</a></td>
-<td class="signwriting">񁭱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00216.html">S167</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00243.html">S1a1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00256.html">S1bc</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00061.html">S121</a></td>
-<td class="signwriting">񀱱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00142.html">S1a5</a></td>
-<td class="signwriting">񃷱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00127.html">S173</a></td>
-<td class="signwriting">񂬱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00240.html">S19b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00065.html">S142</a></td>
-<td class="signwriting">񁣑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00215.html">S166</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00110.html">S1e4</a></td>
-<td class="signwriting">񅖑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00210.html">S161</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00212.html">S163</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00055.html">S1b0</a></td>
-<td class="signwriting">񄈑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00153.html">S1c1</a></td>
-<td class="signwriting">񄡱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00267.html">S1cf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00278.html">S1fe</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00206.html">S15b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00095.html">S158</a></td>
+<td class="signwriting col-signwriting-1">񂄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00082.html">S14b</a></td>
+<td class="signwriting col-signwriting-1">񁰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00058.html">S112</a></td>
+<td class="signwriting col-signwriting-1">񀛑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00085.html">S149</a></td>
+<td class="signwriting col-signwriting-1">񁭱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00216.html">S167</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00243.html">S1a1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00256.html">S1bc</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00061.html">S121</a></td>
+<td class="signwriting col-signwriting-1">񀱱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00142.html">S1a5</a></td>
+<td class="signwriting col-signwriting-1">񃷱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00127.html">S173</a></td>
+<td class="signwriting col-signwriting-1">񂬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00240.html">S19b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00065.html">S142</a></td>
+<td class="signwriting col-signwriting-1">񁣑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00215.html">S166</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00110.html">S1e4</a></td>
+<td class="signwriting col-signwriting-1">񅖑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00210.html">S161</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00212.html">S163</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00055.html">S1b0</a></td>
+<td class="signwriting col-signwriting-1">񄈑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00153.html">S1c1</a></td>
+<td class="signwriting col-signwriting-1">񄡱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00267.html">S1cf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00074.html
+++ b/docs/inventories/inv00074.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>PSL (SP_87)</title>
+  <title>Inventory: PSL (SP_87)</title>
   
 <style>
 @font-face {
@@ -12,150 +12,372 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>PSL (SP_87)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00074</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>PSL (SP_87)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Pakistan Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_87</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: PSL (SP_87)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00074</td>
+<td class="col-language-name">Pakistan Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00075.html
+++ b/docs/inventories/inv00075.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>PJM (SP_19)</title>
+  <title>Inventory: PJM (SP_19)</title>
   
 <style>
 @font-face {
@@ -12,879 +12,1101 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>PJM (SP_19)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00075</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>PJM (SP_19)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Polish Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_19</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: PJM (SP_19)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00075</td>
+<td class="col-language-name">Polish Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00223.html">S175</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00224.html">S178</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00268.html">S1d9</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00211.html">S162</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00062.html">S122</a></td>
-<td class="signwriting">񀳑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00256.html">S1bc</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00207.html">S15c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00061.html">S121</a></td>
-<td class="signwriting">񀱱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00227.html">S17b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00127.html">S173</a></td>
-<td class="signwriting">񂬱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00040.html">S132</a></td>
-<td class="signwriting">񁋑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00159.html">S1d8</a></td>
-<td class="signwriting">񅄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00225.html">S179</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00087.html">S16e</a></td>
-<td class="signwriting">񂥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_nonspread</td>
-<td>extended</td>
-<td><a href="../segments/seg00066.html">S18e</a></td>
-<td class="signwriting">񃕑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00228.html">S17f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00095.html">S158</a></td>
-<td class="signwriting">񂄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00041.html">S13e</a></td>
-<td class="signwriting">񁝑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00088.html">S170</a></td>
-<td class="signwriting">񂨑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00167.html">S1cd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00082.html">S14b</a></td>
-<td class="signwriting">񁰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00183.html">S124</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00157.html">S1d3</a></td>
-<td class="signwriting">񄼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00221.html">S172</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00223.html">S175</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00224.html">S178</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00268.html">S1d9</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00211.html">S162</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00062.html">S122</a></td>
+<td class="signwriting col-signwriting-1">񀳑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00256.html">S1bc</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00207.html">S15c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00061.html">S121</a></td>
+<td class="signwriting col-signwriting-1">񀱱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00227.html">S17b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00127.html">S173</a></td>
+<td class="signwriting col-signwriting-1">񂬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00040.html">S132</a></td>
+<td class="signwriting col-signwriting-1">񁋑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00159.html">S1d8</a></td>
+<td class="signwriting col-signwriting-1">񅄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00225.html">S179</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00087.html">S16e</a></td>
+<td class="signwriting col-signwriting-1">񂥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00066.html">S18e</a></td>
+<td class="signwriting col-signwriting-1">񃕑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00228.html">S17f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00095.html">S158</a></td>
+<td class="signwriting col-signwriting-1">񂄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00041.html">S13e</a></td>
+<td class="signwriting col-signwriting-1">񁝑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00088.html">S170</a></td>
+<td class="signwriting col-signwriting-1">񂨑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00167.html">S1cd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00082.html">S14b</a></td>
+<td class="signwriting col-signwriting-1">񁰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00183.html">S124</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00157.html">S1d3</a></td>
+<td class="signwriting col-signwriting-1">񄼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00221.html">S172</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00076.html
+++ b/docs/inventories/inv00076.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LGP (SP_33)</title>
+  <title>Inventory: LGP (SP_33)</title>
   
 <style>
 @font-face {
@@ -12,816 +12,1038 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LGP (SP_33)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00076</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LGP (SP_33)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Portuguese Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_33</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LGP (SP_33)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00076</td>
+<td class="col-language-name">Portuguese Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00046.html">S116</a></td>
-<td class="signwriting">񀡑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00209.html">S15f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00123.html">S12b</a></td>
-<td class="signwriting">񁀱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00265.html">S1ca</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00110.html">S1e4</a></td>
-<td class="signwriting">񅖑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00153.html">S1c1</a></td>
-<td class="signwriting">񄡱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00147.html">S1d5</a></td>
-<td class="signwriting">񄿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00271.html">S1e6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00160.html">S105</a></td>
-<td class="signwriting">񀇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00243.html">S1a1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00228.html">S17f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00148.html">S1d6</a></td>
-<td class="signwriting">񅁑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00159.html">S1d8</a></td>
-<td class="signwriting">񅄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00186.html">S12f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00082.html">S14b</a></td>
-<td class="signwriting">񁰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00193.html">S137</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00200.html">S143</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00065.html">S142</a></td>
-<td class="signwriting">񁣑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00199.html">S141</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00269.html">S1db</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00046.html">S116</a></td>
+<td class="signwriting col-signwriting-1">񀡑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00209.html">S15f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00123.html">S12b</a></td>
+<td class="signwriting col-signwriting-1">񁀱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00265.html">S1ca</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00110.html">S1e4</a></td>
+<td class="signwriting col-signwriting-1">񅖑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00153.html">S1c1</a></td>
+<td class="signwriting col-signwriting-1">񄡱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00147.html">S1d5</a></td>
+<td class="signwriting col-signwriting-1">񄿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00271.html">S1e6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00160.html">S105</a></td>
+<td class="signwriting col-signwriting-1">񀇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00243.html">S1a1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00228.html">S17f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00148.html">S1d6</a></td>
+<td class="signwriting col-signwriting-1">񅁑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00159.html">S1d8</a></td>
+<td class="signwriting col-signwriting-1">񅄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00186.html">S12f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00082.html">S14b</a></td>
+<td class="signwriting col-signwriting-1">񁰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00193.html">S137</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00200.html">S143</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00065.html">S142</a></td>
+<td class="signwriting col-signwriting-1">񁣑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00199.html">S141</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00269.html">S1db</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00077.html
+++ b/docs/inventories/inv00077.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LSPy (SP_129)</title>
+  <title>Inventory: LSPy (SP_129)</title>
   
 <style>
 @font-face {
@@ -12,1086 +12,1308 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LSPy (SP_129)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00077</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LSPy (SP_129)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Paraguayan Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_129</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LSPy (SP_129)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00077</td>
+<td class="col-language-name">Paraguayan Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00215.html">S166</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00224.html">S178</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00065.html">S142</a></td>
-<td class="signwriting">񁣑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00164.html">S14d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00189.html">S133</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00222.html">S174</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00203.html">S151</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00095.html">S158</a></td>
-<td class="signwriting">񂄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00085.html">S149</a></td>
-<td class="signwriting">񁭱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00087.html">S16e</a></td>
-<td class="signwriting">񂥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00014.html">S103</a></td>
-<td class="signwriting">񀄱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00228.html">S17f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00227.html">S17b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00223.html">S175</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00272.html">S1e8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00216.html">S167</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00207.html">S15c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00225.html">S179</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00009.html">S1ff</a></td>
-<td class="signwriting">񅾱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00174.html">S10f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00202.html">S14f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00110.html">S1e4</a></td>
-<td class="signwriting">񅖑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00124.html">S127</a></td>
-<td class="signwriting">񀺱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00208.html">S15e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00058.html">S112</a></td>
-<td class="signwriting">񀛑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00226.html">S17a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00102.html">S1a7</a></td>
-<td class="signwriting">񃺱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00052.html">S125</a></td>
-<td class="signwriting">񀷱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00185.html">S12e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00184.html">S12c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00023.html">S1df</a></td>
-<td class="signwriting">񅎱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00200.html">S143</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00088.html">S170</a></td>
-<td class="signwriting">񂨑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00118.html">S1a3</a></td>
-<td class="signwriting">񃴱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00172.html">S109</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00062.html">S122</a></td>
-<td class="signwriting">񀳑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00157.html">S1d3</a></td>
-<td class="signwriting">񄼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00269.html">S1db</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00105.html">S1e5</a></td>
-<td class="signwriting">񅗱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00215.html">S166</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00224.html">S178</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00065.html">S142</a></td>
+<td class="signwriting col-signwriting-1">񁣑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00164.html">S14d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00189.html">S133</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00222.html">S174</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00203.html">S151</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00095.html">S158</a></td>
+<td class="signwriting col-signwriting-1">񂄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00085.html">S149</a></td>
+<td class="signwriting col-signwriting-1">񁭱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00087.html">S16e</a></td>
+<td class="signwriting col-signwriting-1">񂥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00014.html">S103</a></td>
+<td class="signwriting col-signwriting-1">񀄱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00228.html">S17f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00227.html">S17b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00223.html">S175</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00272.html">S1e8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00216.html">S167</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00207.html">S15c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00225.html">S179</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00009.html">S1ff</a></td>
+<td class="signwriting col-signwriting-1">񅾱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00174.html">S10f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00202.html">S14f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00110.html">S1e4</a></td>
+<td class="signwriting col-signwriting-1">񅖑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00124.html">S127</a></td>
+<td class="signwriting col-signwriting-1">񀺱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00208.html">S15e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00058.html">S112</a></td>
+<td class="signwriting col-signwriting-1">񀛑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00226.html">S17a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00102.html">S1a7</a></td>
+<td class="signwriting col-signwriting-1">񃺱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00052.html">S125</a></td>
+<td class="signwriting col-signwriting-1">񀷱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00185.html">S12e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00184.html">S12c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00023.html">S1df</a></td>
+<td class="signwriting col-signwriting-1">񅎱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00200.html">S143</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00088.html">S170</a></td>
+<td class="signwriting col-signwriting-1">񂨑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00118.html">S1a3</a></td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00172.html">S109</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00062.html">S122</a></td>
+<td class="signwriting col-signwriting-1">񀳑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00157.html">S1d3</a></td>
+<td class="signwriting col-signwriting-1">񄼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00269.html">S1db</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00105.html">S1e5</a></td>
+<td class="signwriting col-signwriting-1">񅗱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00078.html
+++ b/docs/inventories/inv00078.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LSR (SP_132)</title>
+  <title>Inventory: LSR (SP_132)</title>
   
 <style>
 @font-face {
@@ -12,240 +12,462 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LSR (SP_132)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00078</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LSR (SP_132)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Romanian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_132</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LSR (SP_132)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00078</td>
+<td class="col-language-name">Romanian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00227.html">S17b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00227.html">S17b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00079.html
+++ b/docs/inventories/inv00079.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>RSL (SP_88)</title>
+  <title>Inventory: RSL (SP_88)</title>
   
 <style>
 @font-face {
@@ -12,582 +12,804 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>RSL (SP_88)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00079</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>RSL (SP_88)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Russian-Tajik Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_88</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: RSL (SP_88)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00079</td>
+<td class="col-language-name">Russian-Tajik Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00142.html">S1a5</a></td>
-<td class="signwriting">񃷱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00142.html">S1a5</a></td>
+<td class="signwriting col-signwriting-1">񃷱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00251.html">S1b1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00251.html">S1b1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00178.html">S117</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00178.html">S117</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00230.html">S183</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00230.html">S183</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00161.html">S196</a></td>
-<td class="signwriting">񃡑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00161.html">S196</a></td>
+<td class="signwriting col-signwriting-1">񃡑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00061.html">S121</a></td>
-<td class="signwriting">񀱱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00061.html">S121</a></td>
+<td class="signwriting col-signwriting-1">񀱱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00218.html">S16a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00218.html">S16a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00202.html">S14f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00202.html">S14f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00080.html
+++ b/docs/inventories/inv00080.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>SSL, SASL (SP_40)</title>
+  <title>Inventory: SSL, SASL (SP_40)</title>
   
 <style>
 @font-face {
@@ -12,780 +12,1002 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>SSL, SASL (SP_40)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00080</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>SSL, SASL (SP_40)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_40</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: SSL, SASL (SP_40)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00080</td>
+<td class="col-language-name">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00203.html">S151</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00171.html">S107</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00225.html">S179</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00123.html">S12b</a></td>
-<td class="signwriting">񁀱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00241.html">S19d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00207.html">S15c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00065.html">S142</a></td>
-<td class="signwriting">񁣑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00059.html">S123</a></td>
-<td class="signwriting">񀴱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00224.html">S178</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00177.html">S114</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00181.html">S11f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00243.html">S1a1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00202.html">S14f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00230.html">S183</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00240.html">S19b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00173.html">S10d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00223.html">S175</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00160.html">S105</a></td>
-<td class="signwriting">񀇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00231.html">S184</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00014.html">S103</a></td>
-<td class="signwriting">񀄱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00048.html">S11d</a></td>
-<td class="signwriting">񀫡</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00027.html">S1f3</a></td>
-<td class="signwriting">񅬱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00142.html">S1a5</a></td>
-<td class="signwriting">񃷱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00085.html">S149</a></td>
-<td class="signwriting">񁭱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00203.html">S151</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00171.html">S107</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00225.html">S179</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00123.html">S12b</a></td>
+<td class="signwriting col-signwriting-1">񁀱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00241.html">S19d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00207.html">S15c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00065.html">S142</a></td>
+<td class="signwriting col-signwriting-1">񁣑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00059.html">S123</a></td>
+<td class="signwriting col-signwriting-1">񀴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00224.html">S178</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00177.html">S114</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00181.html">S11f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00243.html">S1a1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00202.html">S14f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00230.html">S183</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00240.html">S19b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00173.html">S10d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00223.html">S175</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00160.html">S105</a></td>
+<td class="signwriting col-signwriting-1">񀇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00231.html">S184</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00014.html">S103</a></td>
+<td class="signwriting col-signwriting-1">񀄱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00048.html">S11d</a></td>
+<td class="signwriting col-signwriting-1">񀫡</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00027.html">S1f3</a></td>
+<td class="signwriting col-signwriting-1">񅬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00142.html">S1a5</a></td>
+<td class="signwriting col-signwriting-1">񃷱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00085.html">S149</a></td>
+<td class="signwriting col-signwriting-1">񁭱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00081.html
+++ b/docs/inventories/inv00081.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>SSL, STS (SP_73)</title>
+  <title>Inventory: SSL, STS (SP_73)</title>
   
 <style>
 @font-face {
@@ -12,330 +12,552 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>SSL, STS (SP_73)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00081</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>SSL, STS (SP_73)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Swedish Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_73</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: SSL, STS (SP_73)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00081</td>
+<td class="col-language-name">Swedish Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00020.html">S1c6</a></td>
-<td class="signwriting">񄩁</td>
-<td class="signwriting">񄩑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00020.html">S1c6</a></td>
+<td class="signwriting col-signwriting-1">񄩁</td>
+<td class="signwriting col-signwriting-2">񄩑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00159.html">S1d8</a></td>
-<td class="signwriting">񅄑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00159.html">S1d8</a></td>
+<td class="signwriting col-signwriting-1">񅄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00082.html
+++ b/docs/inventories/inv00082.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>SgSL (SP_11)</title>
+  <title>Inventory: SgSL (SP_11)</title>
   
 <style>
 @font-face {
@@ -12,888 +12,1110 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>SgSL (SP_11)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00082</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>SgSL (SP_11)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Singapore Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_11</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: SgSL (SP_11)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00082</td>
+<td class="col-language-name">Singapore Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00215.html">S166</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00206.html">S15b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00164.html">S14d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00014.html">S103</a></td>
-<td class="signwriting">񀄱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00110.html">S1e4</a></td>
-<td class="signwriting">񅖑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00209.html">S15f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00153.html">S1c1</a></td>
-<td class="signwriting">񄡱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00225.html">S179</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00174.html">S10f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00203.html">S151</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00160.html">S105</a></td>
-<td class="signwriting">񀇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00270.html">S1e3</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00030.html">S198</a></td>
-<td class="signwriting">񃤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00226.html">S17a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00227.html">S17b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00040.html">S132</a></td>
-<td class="signwriting">񁋑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00228.html">S17f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00170.html">S104</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00142.html">S1a5</a></td>
-<td class="signwriting">񃷱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00109.html">S19f</a></td>
-<td class="signwriting">񃮱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00207.html">S15c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00260.html">S1c0</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00215.html">S166</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00206.html">S15b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00164.html">S14d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00014.html">S103</a></td>
+<td class="signwriting col-signwriting-1">񀄱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00110.html">S1e4</a></td>
+<td class="signwriting col-signwriting-1">񅖑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00209.html">S15f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00153.html">S1c1</a></td>
+<td class="signwriting col-signwriting-1">񄡱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00225.html">S179</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00174.html">S10f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00203.html">S151</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00160.html">S105</a></td>
+<td class="signwriting col-signwriting-1">񀇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00270.html">S1e3</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00030.html">S198</a></td>
+<td class="signwriting col-signwriting-1">񃤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00226.html">S17a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00227.html">S17b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00040.html">S132</a></td>
+<td class="signwriting col-signwriting-1">񁋑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00228.html">S17f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00170.html">S104</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00142.html">S1a5</a></td>
+<td class="signwriting col-signwriting-1">񃷱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00109.html">S19f</a></td>
+<td class="signwriting col-signwriting-1">񃮱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00207.html">S15c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00260.html">S1c0</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00083.html
+++ b/docs/inventories/inv00083.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>SPJ (SP_89)</title>
+  <title>Inventory: SPJ (SP_89)</title>
   
 <style>
 @font-face {
@@ -12,96 +12,318 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>SPJ (SP_89)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00083</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>SPJ (SP_89)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Slovakian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_89</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: SPJ (SP_89)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00083</td>
+<td class="col-language-name">Slovakian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00084.html
+++ b/docs/inventories/inv00084.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LESSA (SP_137)</title>
+  <title>Inventory: LESSA (SP_137)</title>
   
 <style>
 @font-face {
@@ -12,78 +12,300 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LESSA (SP_137)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00084</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LESSA (SP_137)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Salvadoran Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_137</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LESSA (SP_137)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00084</td>
+<td class="col-language-name">Salvadoran Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00085.html
+++ b/docs/inventories/inv00085.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>TSL, MSTSL (SP_34)</title>
+  <title>Inventory: TSL, MSTSL (SP_34)</title>
   
 <style>
 @font-face {
@@ -12,924 +12,1146 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>TSL, MSTSL (SP_34)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00085</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>TSL, MSTSL (SP_34)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Thai Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_34</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: TSL, MSTSL (SP_34)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00085</td>
+<td class="col-language-name">Thai Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00088.html">S170</a></td>
-<td class="signwriting">񂨑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00164.html">S14d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00221.html">S172</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00207.html">S15c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00007.html">S1fc</a></td>
-<td class="signwriting">񅺡</td>
-<td class="signwriting">񅺑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00008.html">S1fd</a></td>
-<td class="signwriting">񅼁</td>
-<td class="signwriting">񅻱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>extended</td>
-<td><a href="../segments/seg00074.html">S1c4</a></td>
-<td class="signwriting">񄦑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00276.html">S1f6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00142.html">S1a5</a></td>
-<td class="signwriting">񃷱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00234.html">S189</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00118.html">S1a3</a></td>
-<td class="signwriting">񃴱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00110.html">S1e4</a></td>
-<td class="signwriting">񅖑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00208.html">S15e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00030.html">S198</a></td>
-<td class="signwriting">񃤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00140.html">S18b</a></td>
-<td class="signwriting">񃐱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00199.html">S141</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_spread</td>
-<td>extended</td>
-<td><a href="../segments/seg00071.html">S18f</a></td>
-<td class="signwriting">񃖱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00147.html">S1d5</a></td>
-<td class="signwriting">񄿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00206.html">S15b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00203.html">S151</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00264.html">S1c9</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00269.html">S1db</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00209.html">S15f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00058.html">S112</a></td>
-<td class="signwriting">񀛑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00065.html">S142</a></td>
-<td class="signwriting">񁣑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00019.html">S1ae</a></td>
-<td class="signwriting">񄅑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00095.html">S158</a></td>
-<td class="signwriting">񂄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00225.html">S179</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00180.html">S11c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00088.html">S170</a></td>
+<td class="signwriting col-signwriting-1">񂨑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00164.html">S14d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00221.html">S172</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00207.html">S15c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00007.html">S1fc</a></td>
+<td class="signwriting col-signwriting-1">񅺡</td>
+<td class="signwriting col-signwriting-2">񅺑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00008.html">S1fd</a></td>
+<td class="signwriting col-signwriting-1">񅼁</td>
+<td class="signwriting col-signwriting-2">񅻱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00074.html">S1c4</a></td>
+<td class="signwriting col-signwriting-1">񄦑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00276.html">S1f6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00142.html">S1a5</a></td>
+<td class="signwriting col-signwriting-1">񃷱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00234.html">S189</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00118.html">S1a3</a></td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00110.html">S1e4</a></td>
+<td class="signwriting col-signwriting-1">񅖑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00208.html">S15e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00030.html">S198</a></td>
+<td class="signwriting col-signwriting-1">񃤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00140.html">S18b</a></td>
+<td class="signwriting col-signwriting-1">񃐱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00199.html">S141</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00071.html">S18f</a></td>
+<td class="signwriting col-signwriting-1">񃖱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00147.html">S1d5</a></td>
+<td class="signwriting col-signwriting-1">񄿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00206.html">S15b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00203.html">S151</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00264.html">S1c9</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00269.html">S1db</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00209.html">S15f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00058.html">S112</a></td>
+<td class="signwriting col-signwriting-1">񀛑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00065.html">S142</a></td>
+<td class="signwriting col-signwriting-1">񁣑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00019.html">S1ae</a></td>
+<td class="signwriting col-signwriting-1">񄅑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00095.html">S158</a></td>
+<td class="signwriting col-signwriting-1">񂄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00225.html">S179</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00180.html">S11c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00086.html
+++ b/docs/inventories/inv00086.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>TunSL (SP_104)</title>
+  <title>Inventory: TunSL (SP_104)</title>
   
 <style>
 @font-face {
@@ -12,1554 +12,1776 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>TunSL (SP_104)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00086</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>TunSL (SP_104)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Tunisian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_104</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: TunSL (SP_104)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00086</td>
+<td class="col-language-name">Tunisian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00058.html">S112</a></td>
-<td class="signwriting">񀛑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00228.html">S17f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00110.html">S1e4</a></td>
-<td class="signwriting">񅖑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00082.html">S14b</a></td>
-<td class="signwriting">񁰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00224.html">S178</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00124.html">S127</a></td>
-<td class="signwriting">񀺱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00216.html">S167</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00062.html">S122</a></td>
-<td class="signwriting">񀳑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00095.html">S158</a></td>
-<td class="signwriting">񂄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00223.html">S175</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00157.html">S1d3</a></td>
-<td class="signwriting">񄼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00040.html">S132</a></td>
-<td class="signwriting">񁋑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00059.html">S123</a></td>
-<td class="signwriting">񀴱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00065.html">S142</a></td>
-<td class="signwriting">񁣑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00085.html">S149</a></td>
-<td class="signwriting">񁭱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00217.html">S169</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00087.html">S16e</a></td>
-<td class="signwriting">񂥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00256.html">S1bc</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00061.html">S121</a></td>
-<td class="signwriting">񀱱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00194.html">S138</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00267.html">S1cf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00023.html">S1df</a></td>
-<td class="signwriting">񅎱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00263.html">S1c8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00190.html">S134</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00094.html">S146</a></td>
-<td class="signwriting">񁩑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00261.html">S1c2</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00270.html">S1e3</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00086.html">S168</a></td>
-<td class="signwriting">񂜑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00241.html">S19d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00219.html">S16b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00123.html">S12b</a></td>
-<td class="signwriting">񁀱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00265.html">S1ca</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00118.html">S1a3</a></td>
-<td class="signwriting">񃴱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00153.html">S1c1</a></td>
-<td class="signwriting">񄡱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00096.html">S159</a></td>
-<td class="signwriting">񂅱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00127.html">S173</a></td>
-<td class="signwriting">񂬱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00269.html">S1db</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00227.html">S17b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00246.html">S1a8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00024.html">S1e0</a></td>
-<td class="signwriting">񅐁</td>
-<td class="signwriting">񅐑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00140.html">S18b</a></td>
-<td class="signwriting">񃐱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00244.html">S1a2</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00030.html">S198</a></td>
-<td class="signwriting">񃤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00032.html">S1e2</a></td>
-<td class="signwriting">񅓁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00185.html">S12e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00191.html">S135</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00141.html">S1a4</a></td>
-<td class="signwriting">񃶁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00143.html">S1ba</a></td>
-<td class="signwriting">񄗁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00048.html">S11d</a></td>
-<td class="signwriting">񀫡</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00209.html">S15f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00147.html">S1d5</a></td>
-<td class="signwriting">񄿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00176.html">S113</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00171.html">S107</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00015.html">S108</a></td>
-<td class="signwriting">񀌑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00017.html">S193</a></td>
-<td class="signwriting">񃜱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00102.html">S1a7</a></td>
-<td class="signwriting">񃺱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00245.html">S1a6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00167.html">S1cd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00142.html">S1a5</a></td>
-<td class="signwriting">񃷱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00260.html">S1c0</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00225.html">S179</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00177.html">S114</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00230.html">S183</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00026.html">S1f2</a></td>
-<td class="signwriting">񅫁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00243.html">S1a1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00215.html">S166</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00088.html">S170</a></td>
-<td class="signwriting">񂨑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_nonspread</td>
-<td>extended</td>
-<td><a href="../segments/seg00066.html">S18e</a></td>
-<td class="signwriting">񃕑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00186.html">S12f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00057.html">S1cb</a></td>
-<td class="signwriting">񄰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00014.html">S103</a></td>
-<td class="signwriting">񀄱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00183.html">S124</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00122.html">S12a</a></td>
-<td class="signwriting">񀿑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00160.html">S105</a></td>
-<td class="signwriting">񀇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00268.html">S1d9</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00206.html">S15b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00027.html">S1f3</a></td>
-<td class="signwriting">񅬱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00148.html">S1d6</a></td>
-<td class="signwriting">񅁑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00091.html">S1d7</a></td>
-<td class="signwriting">񅂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00020.html">S1c6</a></td>
-<td class="signwriting">񄩁</td>
-<td class="signwriting">񄩑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00240.html">S19b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00203.html">S151</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00159.html">S1d8</a></td>
-<td class="signwriting">񅄑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00058.html">S112</a></td>
+<td class="signwriting col-signwriting-1">񀛑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00228.html">S17f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00110.html">S1e4</a></td>
+<td class="signwriting col-signwriting-1">񅖑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00082.html">S14b</a></td>
+<td class="signwriting col-signwriting-1">񁰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00224.html">S178</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00124.html">S127</a></td>
+<td class="signwriting col-signwriting-1">񀺱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00216.html">S167</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00062.html">S122</a></td>
+<td class="signwriting col-signwriting-1">񀳑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00095.html">S158</a></td>
+<td class="signwriting col-signwriting-1">񂄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00223.html">S175</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00157.html">S1d3</a></td>
+<td class="signwriting col-signwriting-1">񄼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00040.html">S132</a></td>
+<td class="signwriting col-signwriting-1">񁋑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00059.html">S123</a></td>
+<td class="signwriting col-signwriting-1">񀴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00065.html">S142</a></td>
+<td class="signwriting col-signwriting-1">񁣑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00085.html">S149</a></td>
+<td class="signwriting col-signwriting-1">񁭱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00217.html">S169</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00087.html">S16e</a></td>
+<td class="signwriting col-signwriting-1">񂥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00256.html">S1bc</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00061.html">S121</a></td>
+<td class="signwriting col-signwriting-1">񀱱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00194.html">S138</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00267.html">S1cf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00023.html">S1df</a></td>
+<td class="signwriting col-signwriting-1">񅎱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00263.html">S1c8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00190.html">S134</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00094.html">S146</a></td>
+<td class="signwriting col-signwriting-1">񁩑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00261.html">S1c2</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00270.html">S1e3</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00086.html">S168</a></td>
+<td class="signwriting col-signwriting-1">񂜑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00241.html">S19d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00219.html">S16b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00123.html">S12b</a></td>
+<td class="signwriting col-signwriting-1">񁀱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00265.html">S1ca</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00118.html">S1a3</a></td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00153.html">S1c1</a></td>
+<td class="signwriting col-signwriting-1">񄡱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00096.html">S159</a></td>
+<td class="signwriting col-signwriting-1">񂅱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00127.html">S173</a></td>
+<td class="signwriting col-signwriting-1">񂬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00269.html">S1db</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00227.html">S17b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00246.html">S1a8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00024.html">S1e0</a></td>
+<td class="signwriting col-signwriting-1">񅐁</td>
+<td class="signwriting col-signwriting-2">񅐑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00140.html">S18b</a></td>
+<td class="signwriting col-signwriting-1">񃐱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00244.html">S1a2</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00030.html">S198</a></td>
+<td class="signwriting col-signwriting-1">񃤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00032.html">S1e2</a></td>
+<td class="signwriting col-signwriting-1">񅓁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00185.html">S12e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00191.html">S135</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00141.html">S1a4</a></td>
+<td class="signwriting col-signwriting-1">񃶁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00143.html">S1ba</a></td>
+<td class="signwriting col-signwriting-1">񄗁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00048.html">S11d</a></td>
+<td class="signwriting col-signwriting-1">񀫡</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00209.html">S15f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00147.html">S1d5</a></td>
+<td class="signwriting col-signwriting-1">񄿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00176.html">S113</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00171.html">S107</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00015.html">S108</a></td>
+<td class="signwriting col-signwriting-1">񀌑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00017.html">S193</a></td>
+<td class="signwriting col-signwriting-1">񃜱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00102.html">S1a7</a></td>
+<td class="signwriting col-signwriting-1">񃺱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00245.html">S1a6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00167.html">S1cd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00142.html">S1a5</a></td>
+<td class="signwriting col-signwriting-1">񃷱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00260.html">S1c0</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00225.html">S179</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00177.html">S114</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00230.html">S183</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00026.html">S1f2</a></td>
+<td class="signwriting col-signwriting-1">񅫁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00243.html">S1a1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00215.html">S166</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00088.html">S170</a></td>
+<td class="signwriting col-signwriting-1">񂨑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00066.html">S18e</a></td>
+<td class="signwriting col-signwriting-1">񃕑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00186.html">S12f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00057.html">S1cb</a></td>
+<td class="signwriting col-signwriting-1">񄰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00014.html">S103</a></td>
+<td class="signwriting col-signwriting-1">񀄱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00183.html">S124</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00122.html">S12a</a></td>
+<td class="signwriting col-signwriting-1">񀿑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00160.html">S105</a></td>
+<td class="signwriting col-signwriting-1">񀇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00268.html">S1d9</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00206.html">S15b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00027.html">S1f3</a></td>
+<td class="signwriting col-signwriting-1">񅬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00148.html">S1d6</a></td>
+<td class="signwriting col-signwriting-1">񅁑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00091.html">S1d7</a></td>
+<td class="signwriting col-signwriting-1">񅂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00020.html">S1c6</a></td>
+<td class="signwriting col-signwriting-1">񄩁</td>
+<td class="signwriting col-signwriting-2">񄩑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00240.html">S19b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00203.html">S151</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00159.html">S1d8</a></td>
+<td class="signwriting col-signwriting-1">񅄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00087.html
+++ b/docs/inventories/inv00087.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>TİD (SP_90)</title>
+  <title>Inventory: TİD (SP_90)</title>
   
 <style>
 @font-face {
@@ -12,78 +12,300 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>TİD (SP_90)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00087</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>TİD (SP_90)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Turkish Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_90</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: TİD (SP_90)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00087</td>
+<td class="col-language-name">Turkish Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00088.html
+++ b/docs/inventories/inv00088.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>TSL (SP_75)</title>
+  <title>Inventory: TSL (SP_75)</title>
   
 <style>
 @font-face {
@@ -12,636 +12,858 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>TSL (SP_75)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00088</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>TSL (SP_75)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Taiwan Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_75</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: TSL (SP_75)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00088</td>
+<td class="col-language-name">Taiwan Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00019.html">S1ae</a></td>
-<td class="signwriting">񄅑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00019.html">S1ae</a></td>
+<td class="signwriting col-signwriting-1">񄅑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00020.html">S1c6</a></td>
-<td class="signwriting">񄩁</td>
-<td class="signwriting">񄩑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00020.html">S1c6</a></td>
+<td class="signwriting col-signwriting-1">񄩁</td>
+<td class="signwriting col-signwriting-2">񄩑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00207.html">S15c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00207.html">S15c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00127.html">S173</a></td>
-<td class="signwriting">񂬱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00127.html">S173</a></td>
+<td class="signwriting col-signwriting-1">񂬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00118.html">S1a3</a></td>
-<td class="signwriting">񃴱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00118.html">S1a3</a></td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00216.html">S167</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00216.html">S167</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00048.html">S11d</a></td>
-<td class="signwriting">񀫡</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00048.html">S11d</a></td>
+<td class="signwriting col-signwriting-1">񀫡</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00095.html">S158</a></td>
-<td class="signwriting">񂄑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00095.html">S158</a></td>
+<td class="signwriting col-signwriting-1">񂄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00089.html">S171</a></td>
-<td class="signwriting">񂩱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00089.html">S171</a></td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00147.html">S1d5</a></td>
-<td class="signwriting">񄿱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00147.html">S1d5</a></td>
+<td class="signwriting col-signwriting-1">񄿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00219.html">S16b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00219.html">S16b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00088.html">S170</a></td>
-<td class="signwriting">񂨑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00088.html">S170</a></td>
+<td class="signwriting col-signwriting-1">񂨑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00277.html">S1fa</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00277.html">S1fa</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00243.html">S1a1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00243.html">S1a1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00169.html">S102</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00169.html">S102</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00259.html">S1bf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00259.html">S1bf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00091.html">S1d7</a></td>
-<td class="signwriting">񅂱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00091.html">S1d7</a></td>
+<td class="signwriting col-signwriting-1">񅂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00089.html
+++ b/docs/inventories/inv00089.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>LSU (SP_143)</title>
+  <title>Inventory: LSU (SP_143)</title>
   
 <style>
 @font-face {
@@ -12,717 +12,939 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>LSU (SP_143)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00089</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>LSU (SP_143)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Uruguayan Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_143</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: LSU (SP_143)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00089</td>
+<td class="col-language-name">Uruguayan Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00216.html">S167</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00267.html">S1cf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00224.html">S178</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00189.html">S133</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00159.html">S1d8</a></td>
-<td class="signwriting">񅄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00058.html">S112</a></td>
-<td class="signwriting">񀛑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00193.html">S137</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00194.html">S138</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00157.html">S1d3</a></td>
-<td class="signwriting">񄼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00246.html">S1a8</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00235.html">S18a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00192.html">S136</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00228.html">S17f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00123.html">S12b</a></td>
-<td class="signwriting">񁀱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00173.html">S10d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00216.html">S167</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00267.html">S1cf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00224.html">S178</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00189.html">S133</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00159.html">S1d8</a></td>
+<td class="signwriting col-signwriting-1">񅄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00058.html">S112</a></td>
+<td class="signwriting col-signwriting-1">񀛑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00193.html">S137</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00194.html">S138</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00157.html">S1d3</a></td>
+<td class="signwriting col-signwriting-1">񄼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00246.html">S1a8</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00235.html">S18a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00192.html">S136</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00228.html">S17f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00123.html">S12b</a></td>
+<td class="signwriting col-signwriting-1">񁀱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00173.html">S10d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00090.html
+++ b/docs/inventories/inv00090.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>VSL (SP_76)</title>
+  <title>Inventory: VSL (SP_76)</title>
   
 <style>
 @font-face {
@@ -12,474 +12,696 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>VSL (SP_76)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00090</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>VSL (SP_76)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Venezuelan Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_76</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: VSL (SP_76)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00090</td>
+<td class="col-language-name">Venezuelan Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00015.html">S108</a></td>
-<td class="signwriting">񀌑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00015.html">S108</a></td>
+<td class="signwriting col-signwriting-1">񀌑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00184.html">S12c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00184.html">S12c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00234.html">S189</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00234.html">S189</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00215.html">S166</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00215.html">S166</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00091.html
+++ b/docs/inventories/inv00091.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>IS (SP_35)</title>
+  <title>Inventory: IS (SP_35)</title>
   
 <style>
 @font-face {
@@ -12,564 +12,786 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>IS (SP_35)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00091</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>IS (SP_35)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>International Sign</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_35</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: IS (SP_35)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00091</td>
+<td class="col-language-name">International Sign</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00020.html">S1c6</a></td>
-<td class="signwriting">񄩁</td>
-<td class="signwriting">񄩑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00020.html">S1c6</a></td>
+<td class="signwriting col-signwriting-1">񄩁</td>
+<td class="signwriting col-signwriting-2">񄩑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00227.html">S17b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00227.html">S17b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00212.html">S163</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00212.html">S163</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00230.html">S183</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00230.html">S183</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00026.html">S1f2</a></td>
-<td class="signwriting">񅫁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00026.html">S1f2</a></td>
+<td class="signwriting col-signwriting-1">񅫁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00061.html">S121</a></td>
-<td class="signwriting">񀱱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00061.html">S121</a></td>
+<td class="signwriting col-signwriting-1">񀱱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00092.html
+++ b/docs/inventories/inv00092.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>SASL (SP_77)</title>
+  <title>Inventory: SASL (SP_77)</title>
   
 <style>
 @font-face {
@@ -12,636 +12,858 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>SASL (SP_77)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00092</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>SASL (SP_77)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>South African Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_77</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: SASL (SP_77)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00092</td>
+<td class="col-language-name">South African Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00164.html">S14d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00164.html">S14d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00167.html">S1cd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00167.html">S1cd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_nonspread</td>
-<td>extended</td>
-<td><a href="../segments/seg00066.html">S18e</a></td>
-<td class="signwriting">񃕑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00066.html">S18e</a></td>
+<td class="signwriting col-signwriting-1">񃕑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00143.html">S1ba</a></td>
-<td class="signwriting">񄗁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00143.html">S1ba</a></td>
+<td class="signwriting col-signwriting-1">񄗁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00276.html">S1f6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00276.html">S1f6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00118.html">S1a3</a></td>
-<td class="signwriting">񃴱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00118.html">S1a3</a></td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00156.html">S1d2</a></td>
-<td class="signwriting">񄻑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00156.html">S1d2</a></td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00141.html">S1a4</a></td>
-<td class="signwriting">񃶁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00141.html">S1a4</a></td>
+<td class="signwriting col-signwriting-1">񃶁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00110.html">S1e4</a></td>
-<td class="signwriting">񅖑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00110.html">S1e4</a></td>
+<td class="signwriting col-signwriting-1">񅖑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00062.html">S122</a></td>
-<td class="signwriting">񀳑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00062.html">S122</a></td>
+<td class="signwriting col-signwriting-1">񀳑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00137.html">S155</a></td>
-<td class="signwriting">񁿱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00137.html">S155</a></td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00244.html">S1a2</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00244.html">S1a2</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00093.html
+++ b/docs/inventories/inv00093.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Signuno (SP_54)</title>
+  <title>Inventory: Signuno (SP_54)</title>
   
 <style>
 @font-face {
@@ -12,474 +12,696 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Signuno (SP_54)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00093</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>Signuno (SP_54)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Esperanto-SignUno</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_54</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: Signuno (SP_54)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00093</td>
+<td class="col-language-name">Esperanto-SignUno</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00139.html">S187</a></td>
-<td class="signwriting">񃊱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00139.html">S187</a></td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00055.html">S1b0</a></td>
-<td class="signwriting">񄈑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00055.html">S1b0</a></td>
+<td class="signwriting col-signwriting-1">񄈑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00142.html">S1a5</a></td>
-<td class="signwriting">񃷱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00142.html">S1a5</a></td>
+<td class="signwriting col-signwriting-1">񃷱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00212.html">S163</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00212.html">S163</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>3_nonspread</td>
-<td>extended</td>
-<td><a href="../segments/seg00066.html">S18e</a></td>
-<td class="signwriting">񃕑</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw"><a href="../segments/seg00066.html">S18e</a></td>
+<td class="signwriting col-signwriting-1">񃕑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 <tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00154.html">S1c3</a></td>
-<td class="signwriting">񄤱</td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00154.html">S1c3</a></td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/inventories/inv00094.html
+++ b/docs/inventories/inv00094.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>YSL (SP_74)</title>
+  <title>Inventory: YSL (SP_74)</title>
   
 <style>
 @font-face {
@@ -12,1068 +12,1290 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>YSL (SP_74)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Inventory Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Inventory Id</th>
-<td>inv00094</td>
-</tr>
-<tr>
-<th>Inventory Name</th>
-<td>YSL (SP_74)</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Yugoslavian Sign Language</td>
-</tr>
-<tr>
-<th>Data Source</th>
-<td>SP_74</td>
-</tr>
-<tr>
-<th>Contributor</th>
-<td>Luz Diaz</td>
-</tr>
-<tr>
-<th>Cite</th>
-<td>[cite]</td>
-</tr>
-</tbody></table>
 
-  <h2>Segments</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Inventory: YSL (SP_74)</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Segment Class</th>
-<th>Hamnosys 1 Initial Configuration</th>
-<th>Hamnosys 2 Basic Handshape</th>
-<th>Hamnosys 3 Handshape Modifications</th>
-<th>Fsw</th>
-<th>Signwriting 1</th>
-<th>Signwriting 2</th>
+<th class="col-inventory-id">Inventory Id</th>
+<th class="col-language-name">Language Name</th>
+<th class="col-contributor">Contributor</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-inventory-id">inv00094</td>
+<td class="col-language-name">Yugoslavian Sign Language</td>
+<td class="col-contributor">Luz Diaz</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">
+        This page lists the segments associated with a single inventory.
+        <em><strong>Data note:</strong> The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors.</em>
+      </p>
+    </section>
+
+    <section class="content-card">
+      <h2>Segments</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-segment-class">Segment Class</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
 </tr></thead>
 <tbody>
 <tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00080.html">S15a</a></td>
-<td class="signwriting">񂇁</td>
-<td class="signwriting">񂇑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00012.html">S100</a></td>
-<td class="signwriting">񀀁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00093.html">S14c</a></td>
-<td class="signwriting">񁲁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00036.html">S115</a></td>
-<td class="signwriting">񀟱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00081.html">S15d</a></td>
-<td class="signwriting">񂋱</td>
-<td class="signwriting">񂋡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00108.html">S1ed</a></td>
-<td class="signwriting">񅣡</td>
-<td class="signwriting">񅢑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00132.html">S185</a></td>
-<td class="signwriting">񃇱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers Hooked)</td>
-<td><a href="../segments/seg00035.html">S1ea</a></td>
-<td class="signwriting">񅟑</td>
-<td class="signwriting">񅟁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00158.html">S1d4</a></td>
-<td class="signwriting">񄾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00001.html">S1f5</a></td>
-<td class="signwriting">񅯣</td>
-<td class="signwriting">񅯡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00145.html">S1ce</a></td>
-<td class="signwriting">񄵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00021.html">S1dc</a></td>
-<td class="signwriting">񅊑</td>
-<td class="signwriting">񅊡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00050.html">S10e</a></td>
-<td class="signwriting">񀕁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00018.html">S19a</a></td>
-<td class="signwriting">񃧑</td>
-<td class="signwriting">񃧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00229.html">S181</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00099.html">S150</a></td>
-<td class="signwriting">񁸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00029.html">S10a</a></td>
-<td class="signwriting">񀏑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00128.html">S176</a></td>
-<td class="signwriting">񂱑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00083.html">S180</a></td>
-<td class="signwriting">񃀑</td>
-<td class="signwriting">񃀁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00103.html">S1c5</a></td>
-<td class="signwriting">񄧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00113.html">S1f4</a></td>
-<td class="signwriting">񅮁</td>
-<td class="signwriting">񅮑</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00134.html">S153</a></td>
-<td class="signwriting">񁼱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00084.html">S182</a></td>
-<td class="signwriting">񃃑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00092.html">S144</a></td>
-<td class="signwriting">񁦁</td>
-<td class="signwriting">񁦡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00043.html">S118</a></td>
-<td class="signwriting">񀤑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00025.html">S10c</a></td>
-<td class="signwriting">񀒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00273.html">S1ec</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00098.html">S14e</a></td>
-<td class="signwriting">񁵑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00051.html">S11e</a></td>
-<td class="signwriting">񀭁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00022.html">S1de</a></td>
-<td class="signwriting">񅍑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finSpread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00135.html">S154</a></td>
-<td class="signwriting">񁾑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00112.html">S1f0</a></td>
-<td class="signwriting">񅨑</td>
-<td class="signwriting">񅨁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00003.html">S1f8</a></td>
-<td class="signwriting">񅴑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00116.html">S13f</a></td>
-<td class="signwriting">񁞱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers straight)</td>
-<td><a href="../segments/seg00133.html">S160</a></td>
-<td class="signwriting">񂐑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00162.html">S10b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00131.html">S17d</a></td>
-<td class="signwriting">񂻱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00079.html">S147</a></td>
-<td class="signwriting">񁪱</td>
-<td class="signwriting">񁫁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00230.html">S183</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00126.html">S16d</a></td>
-<td class="signwriting">񂣱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00016.html">S192</a></td>
-<td class="signwriting">񃛑</td>
-<td class="signwriting">񃛁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00028.html">S106</a></td>
-<td class="signwriting">񀉑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00224.html">S178</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00064.html">S140</a></td>
-<td class="signwriting">񁠑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00031.html">S1e1</a></td>
-<td class="signwriting">񅑱</td>
-<td class="signwriting">񅑡</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00111.html">S1ee</a></td>
-<td class="signwriting">񅥑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00164.html">S14d</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00220.html">S16c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00039.html">S119</a></td>
-<td class="signwriting">񀥱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00222.html">S174</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>2finger_differshape</td>
-<td><a href="../segments/seg00047.html">S11a</a></td>
-<td class="signwriting">񀧑</td>
-<td class="signwriting">񀧁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00060.html">S110</a></td>
-<td class="signwriting">񀘑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00146.html">S1d0</a></td>
-<td class="signwriting">񄸑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00013.html">S101</a></td>
-<td class="signwriting">񀁱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb flattened)</td>
-<td><a href="../segments/seg00155.html">S1d1</a></td>
-<td class="signwriting">񄹱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00274.html">S1ef</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00129.html">S177</a></td>
-<td class="signwriting">񂲱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00032.html">S1e2</a></td>
-<td class="signwriting">񅓁</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00144.html">S1bb</a></td>
-<td class="signwriting">񄘱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00127.html">S173</a></td>
-<td class="signwriting">񂬱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00275.html">S1f1</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00228.html">S17f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00151.html">S18d</a></td>
-<td class="signwriting">񃓱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00202.html">S14f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_nonspread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00082.html">S14b</a></td>
-<td class="signwriting">񁰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>4finger_differshape</td>
-<td><a href="../segments/seg00101.html">S157</a></td>
-<td class="signwriting">񂂱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00276.html">S1f6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00163.html">S14a</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00165.html">S16f</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00002.html">S1f7</a></td>
-<td class="signwriting">񅲱</td>
-<td class="signwriting">񅳁</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00256.html">S1bc</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00107.html">S1eb</a></td>
-<td class="signwriting">񅠱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00014.html">S103</a></td>
-<td class="signwriting">񀄱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00166.html">S17e</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_nonspread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00037.html">S12d</a></td>
-<td class="signwriting">񁃡</td>
-<td class="signwriting">񁃱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00227.html">S17b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00204.html">S152</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00152.html">S1da</a></td>
-<td class="signwriting">񅇑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00058.html">S112</a></td>
-<td class="signwriting">񀛑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others spread)</td>
-<td><a href="../segments/seg00147.html">S1d5</a></td>
-<td class="signwriting">񄿱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00223.html">S175</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00232.html">S186</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00114.html">S129</a></td>
-<td class="signwriting">񀽱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00205.html">S156</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00167.html">S1cd</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00115.html">S13d</a></td>
-<td class="signwriting">񁛡</td>
-<td class="signwriting">񁛱</td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00206.html">S15b</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(fistDerivation)</td>
-<td><a href="../segments/seg00006.html">S1fb</a></td>
-<td class="signwriting">񅸱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersNonfist</td>
-<td>(thumb rounded,others nonspread)</td>
-<td><a href="../segments/seg00150.html">S18c</a></td>
-<td class="signwriting">񃒑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>1_finger</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00023.html">S1df</a></td>
-<td class="signwriting">񅎱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00203.html">S151</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finNonspread_othersFist</td>
-<td>FlattenedandInFistfingerUp</td>
-<td><a href="../segments/seg00118.html">S1a3</a></td>
-<td class="signwriting">񃴱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00057.html">S1cb</a></td>
-<td class="signwriting">񄰱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00053.html">S19c</a></td>
-<td class="signwriting">񃪑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>0_finger(Fist)</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00005.html">S1f9</a></td>
-<td class="signwriting">񅵱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00180.html">S11c</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>4finNonspread</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00130.html">S17c</a></td>
-<td class="signwriting">񂺑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers flattened)</td>
-<td><a href="../segments/seg00095.html">S158</a></td>
-<td class="signwriting">񂄑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00271.html">S1e6</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00121.html">S128</a></td>
-<td class="signwriting">񀼑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>1fin_othersFist</td>
-<td>(fingers rounded)</td>
-<td><a href="../segments/seg00106.html">S1e7</a></td>
-<td class="signwriting">񅚱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Thumb Opposition</td>
-<td>2finSpread_othersFist</td>
-<td>(fingers flattened)</td>
-<td><a href="../segments/seg00123.html">S12b</a></td>
-<td class="signwriting">񁀱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00172.html">S109</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00225.html">S179</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00175.html">S111</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers extended)</td>
-<td><a href="../segments/seg00054.html">S1a0</a></td>
-<td class="signwriting">񃰑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00177.html">S114</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00176.html">S113</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>4_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00097.html">S145</a></td>
-<td class="signwriting">񁧱</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td>Selected fingers</td>
-<td>2_spread</td>
-<td>(Selected Fingers bent)</td>
-<td><a href="../segments/seg00062.html">S122</a></td>
-<td class="signwriting">񀳑</td>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<td>handshape</td>
-<td></td>
-<td></td>
-<td></td>
-<td><a href="../segments/seg00267.html">S1cf</a></td>
-<td class="signwriting"></td>
-<td class="signwriting"></td>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00080.html">S15a</a></td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00012.html">S100</a></td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00093.html">S14c</a></td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00036.html">S115</a></td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00081.html">S15d</a></td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00108.html">S1ed</a></td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00132.html">S185</a></td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw"><a href="../segments/seg00035.html">S1ea</a></td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00158.html">S1d4</a></td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00001.html">S1f5</a></td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00145.html">S1ce</a></td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00021.html">S1dc</a></td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00050.html">S10e</a></td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00018.html">S19a</a></td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00229.html">S181</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00099.html">S150</a></td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00029.html">S10a</a></td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00128.html">S176</a></td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00083.html">S180</a></td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00103.html">S1c5</a></td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00113.html">S1f4</a></td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00134.html">S153</a></td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00084.html">S182</a></td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00092.html">S144</a></td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00043.html">S118</a></td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00025.html">S10c</a></td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00273.html">S1ec</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00098.html">S14e</a></td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00051.html">S11e</a></td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00022.html">S1de</a></td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00135.html">S154</a></td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00112.html">S1f0</a></td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00003.html">S1f8</a></td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00116.html">S13f</a></td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw"><a href="../segments/seg00133.html">S160</a></td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00162.html">S10b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00131.html">S17d</a></td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00079.html">S147</a></td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00230.html">S183</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00126.html">S16d</a></td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00016.html">S192</a></td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00028.html">S106</a></td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00224.html">S178</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00064.html">S140</a></td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00031.html">S1e1</a></td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00111.html">S1ee</a></td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00164.html">S14d</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00220.html">S16c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00039.html">S119</a></td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00222.html">S174</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00047.html">S11a</a></td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00060.html">S110</a></td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00146.html">S1d0</a></td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00013.html">S101</a></td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00155.html">S1d1</a></td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00274.html">S1ef</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00129.html">S177</a></td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00032.html">S1e2</a></td>
+<td class="signwriting col-signwriting-1">񅓁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00144.html">S1bb</a></td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00127.html">S173</a></td>
+<td class="signwriting col-signwriting-1">񂬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00275.html">S1f1</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00228.html">S17f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00151.html">S18d</a></td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00202.html">S14f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00082.html">S14b</a></td>
+<td class="signwriting col-signwriting-1">񁰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw"><a href="../segments/seg00101.html">S157</a></td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00276.html">S1f6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00163.html">S14a</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00165.html">S16f</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00002.html">S1f7</a></td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00256.html">S1bc</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00107.html">S1eb</a></td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00014.html">S103</a></td>
+<td class="signwriting col-signwriting-1">񀄱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00166.html">S17e</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00037.html">S12d</a></td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00227.html">S17b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00204.html">S152</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00152.html">S1da</a></td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00058.html">S112</a></td>
+<td class="signwriting col-signwriting-1">񀛑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw"><a href="../segments/seg00147.html">S1d5</a></td>
+<td class="signwriting col-signwriting-1">񄿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00223.html">S175</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00232.html">S186</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00114.html">S129</a></td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00205.html">S156</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00167.html">S1cd</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00115.html">S13d</a></td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00206.html">S15b</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw"><a href="../segments/seg00006.html">S1fb</a></td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw"><a href="../segments/seg00150.html">S18c</a></td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00023.html">S1df</a></td>
+<td class="signwriting col-signwriting-1">񅎱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00203.html">S151</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw"><a href="../segments/seg00118.html">S1a3</a></td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00057.html">S1cb</a></td>
+<td class="signwriting col-signwriting-1">񄰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00053.html">S19c</a></td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00005.html">S1f9</a></td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00180.html">S11c</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00130.html">S17c</a></td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00095.html">S158</a></td>
+<td class="signwriting col-signwriting-1">񂄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00271.html">S1e6</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00121.html">S128</a></td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw"><a href="../segments/seg00106.html">S1e7</a></td>
+<td class="signwriting col-signwriting-1">񅚱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw"><a href="../segments/seg00123.html">S12b</a></td>
+<td class="signwriting col-signwriting-1">񁀱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00172.html">S109</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00225.html">S179</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00175.html">S111</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw"><a href="../segments/seg00054.html">S1a0</a></td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00177.html">S114</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00176.html">S113</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00097.html">S145</a></td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw"><a href="../segments/seg00062.html">S122</a></td>
+<td class="signwriting col-signwriting-1">񀳑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr>
+<tr>
+<td class="col-segment-class">handshape</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw"><a href="../segments/seg00267.html">S1cf</a></td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00001.html
+++ b/docs/languages/lan00001.html
@@ -3,58 +3,280 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>American Sign Language</title>
+  <title>Language: American Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>American Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00001</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>American Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>ASL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>afgh1239</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>ase</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>North America</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: American Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00001</td>
+<td class="col-language-abbreviation">ASL</td>
+<td class="col-glottocode">afgh1239</td>
+<td class="col-iso-639-3">ase</td>
+<td class="col-macro-area">North America</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>Longqian Ming (2024)</td>
-<td>48</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-source">Longqian Ming (2024)</td>
+<td class="col-segments">48</td>
+<td class="col-handshapes">48</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>182</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">182</td>
+<td class="col-handshapes">182</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00002.html
+++ b/docs/languages/lan00002.html
@@ -3,58 +3,280 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Chinese Sign Language</title>
+  <title>Language: Chinese Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Chinese Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00002</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Chinese Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>CSL, ZGS </td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>chin1283</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>csl</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Chinese Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00002</td>
+<td class="col-language-abbreviation">CSL, ZGS</td>
+<td class="col-glottocode">chin1283</td>
+<td class="col-iso-639-3">csl</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Longqian Ming (2024)</td>
-<td>58</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-source">Longqian Ming (2024)</td>
+<td class="col-segments">58</td>
+<td class="col-handshapes">58</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>37</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">37</td>
+<td class="col-handshapes">37</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00003.html
+++ b/docs/languages/lan00003.html
@@ -3,58 +3,280 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>German Sign Language</title>
+  <title>Language: German Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>German Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00003</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>German Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>DGS</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>germ1281</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>gsg</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: German Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00003</td>
+<td class="col-language-abbreviation">DGS</td>
+<td class="col-glottocode">germ1281</td>
+<td class="col-iso-639-3">gsg</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>Longqian Ming (2024)</td>
-<td>30</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-source">Longqian Ming (2024)</td>
+<td class="col-segments">30</td>
+<td class="col-handshapes">30</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>97</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">97</td>
+<td class="col-handshapes">97</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00004.html
+++ b/docs/languages/lan00004.html
@@ -3,58 +3,280 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Hong Kong Sign Language or Hong Kong-Macau Sign Language</title>
+  <title>Language: Hong Kong Sign Language or Hong Kong-Macau Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Hong Kong Sign Language or Hong Kong-Macau Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00004</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>HKSL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>hong1241</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>hks</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Hong Kong Sign Language or Hong Kong-Macau Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00004</td>
+<td class="col-language-abbreviation">HKSL</td>
+<td class="col-glottocode">hong1241</td>
+<td class="col-iso-639-3">hks</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Longqian Ming (2024)</td>
-<td>54</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-source">Longqian Ming (2024)</td>
+<td class="col-segments">54</td>
+<td class="col-handshapes">54</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00047.html">HKSL (SP_12)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>3</td>
+<td class="col-inventory"><a href="../inventories/inv00047.html">HKSL (SP_12)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">3</td>
+<td class="col-handshapes">3</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00005.html
+++ b/docs/languages/lan00005.html
@@ -3,58 +3,280 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Swedish Sign Language</title>
+  <title>Language: Swedish Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Swedish Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00005</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Swedish Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>SSL, STS</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>swed1236</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>swl</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Swedish Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00005</td>
+<td class="col-language-abbreviation">SSL, STS</td>
+<td class="col-glottocode">swed1236</td>
+<td class="col-iso-639-3">swl</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Longqian Ming (2024)</td>
-<td>41</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-source">Longqian Ming (2024)</td>
+<td class="col-segments">41</td>
+<td class="col-handshapes">41</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>29</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">29</td>
+<td class="col-handshapes">29</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00006.html
+++ b/docs/languages/lan00006.html
@@ -3,58 +3,280 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>British Sign Language</title>
+  <title>Language: British Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>British Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00006</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>British Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>BSL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>brit1235</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>bfi</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: British Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00006</td>
+<td class="col-language-abbreviation">BSL</td>
+<td class="col-glottocode">brit1235</td>
+<td class="col-iso-639-3">bfi</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>Longqian Ming (2024)</td>
-<td>57</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-source">Longqian Ming (2024)</td>
+<td class="col-segments">57</td>
+<td class="col-handshapes">57</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>89</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">89</td>
+<td class="col-handshapes">89</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00007.html
+++ b/docs/languages/lan00007.html
@@ -3,58 +3,280 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Auslan (Australian Sign Language)</title>
+  <title>Language: Auslan (Australian Sign Language)</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Auslan (Australian Sign Language)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00007</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Auslan (Australian Sign Language)</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>Auslan</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>aust1271</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>asf</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Australia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Auslan <span class="title-extra">(Australian Sign Language)</span></h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00007</td>
+<td class="col-language-abbreviation">Auslan</td>
+<td class="col-glottocode">aust1271</td>
+<td class="col-iso-639-3">asf</td>
+<td class="col-macro-area">Australia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Longqian Ming (2024)</td>
-<td>39</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-source">Longqian Ming (2024)</td>
+<td class="col-segments">39</td>
+<td class="col-handshapes">39</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>57</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">57</td>
+<td class="col-handshapes">57</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00008.html
+++ b/docs/languages/lan00008.html
@@ -3,58 +3,280 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>New Zealand Sign Language</title>
+  <title>Language: New Zealand Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>New Zealand Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00008</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>New Zealand Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>NZSL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>newz1236</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>nzs</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Papunesia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: New Zealand Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00008</td>
+<td class="col-language-abbreviation">NZSL</td>
+<td class="col-glottocode">newz1236</td>
+<td class="col-iso-639-3">nzs</td>
+<td class="col-macro-area">Papunesia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>Longqian Ming (2024)</td>
-<td>58</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-source">Longqian Ming (2024)</td>
+<td class="col-segments">58</td>
+<td class="col-handshapes">58</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>14</td>
+<td class="col-inventory"><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">14</td>
+<td class="col-handshapes">14</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00009.html
+++ b/docs/languages/lan00009.html
@@ -3,58 +3,280 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Taiwan Sign Language</title>
+  <title>Language: Taiwan Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Taiwan Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00009</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Taiwan Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>TSL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>taiw1241</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>tss</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Papunesia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Taiwan Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00009</td>
+<td class="col-language-abbreviation">TSL</td>
+<td class="col-glottocode">taiw1241</td>
+<td class="col-iso-639-3">tss</td>
+<td class="col-macro-area">Papunesia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Longqian Ming (2024)</td>
-<td>57</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-source">Longqian Ming (2024)</td>
+<td class="col-segments">57</td>
+<td class="col-handshapes">57</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>63</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">63</td>
+<td class="col-handshapes">63</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00010.html
+++ b/docs/languages/lan00010.html
@@ -3,58 +3,280 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Korean Sign Language</title>
+  <title>Language: Korean Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Korean Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00010</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Korean Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>KSL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>kore1273</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>kvk</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Korean Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00010</td>
+<td class="col-language-abbreviation">KSL</td>
+<td class="col-glottocode">kore1273</td>
+<td class="col-iso-639-3">kvk</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Longqian Ming (2024)</td>
-<td>61</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-source">Longqian Ming (2024)</td>
+<td class="col-segments">61</td>
+<td class="col-handshapes">61</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>214</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">214</td>
+<td class="col-handshapes">214</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00011.html
+++ b/docs/languages/lan00011.html
@@ -3,58 +3,280 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Danish Sign Language</title>
+  <title>Language: Danish Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Danish Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00011</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Danish Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>DSL, DTS</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>dani1246</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>dsl</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Danish Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00011</td>
+<td class="col-language-abbreviation">DSL, DTS</td>
+<td class="col-glottocode">dani1246</td>
+<td class="col-iso-639-3">dsl</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Longqian Ming (2024)</td>
-<td>61</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-source">Longqian Ming (2024)</td>
+<td class="col-segments">61</td>
+<td class="col-handshapes">61</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>33</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">33</td>
+<td class="col-handshapes">33</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00012.html
+++ b/docs/languages/lan00012.html
@@ -3,58 +3,280 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Dutch Sign Language or Sign Language of the Netherlands</title>
+  <title>Language: Dutch Sign Language or Sign Language of the Netherlands</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Dutch Sign Language or Sign Language of the Netherlands</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00012</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>NGT, SLN</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>dutc1253</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>dse</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Dutch Sign Language or Sign Language of the Netherlands</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00012</td>
+<td class="col-language-abbreviation">NGT, SLN</td>
+<td class="col-glottocode">dutc1253</td>
+<td class="col-iso-639-3">dse</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Longqian Ming (2024)</td>
-<td>73</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-source">Longqian Ming (2024)</td>
+<td class="col-segments">73</td>
+<td class="col-handshapes">73</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>35</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">35</td>
+<td class="col-handshapes">35</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00013.html
+++ b/docs/languages/lan00013.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Afghan Sign Language</title>
+  <title>Language: Afghan Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Afghan Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00013</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Afghan Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>AFSL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>afgh1239</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>afg</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Afghan Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00013</td>
+<td class="col-language-abbreviation">AFSL</td>
+<td class="col-glottocode">afgh1239</td>
+<td class="col-iso-639-3">afg</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00013.html">AFSL (SP_106)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>10</td>
+<td class="col-inventory"><a href="../inventories/inv00013.html">AFSL (SP_106)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">10</td>
+<td class="col-handshapes">10</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00014.html
+++ b/docs/languages/lan00014.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Albanian Sign Language</title>
+  <title>Language: Albanian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Albanian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00014</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Albanian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>AlbSL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>alba1271</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>sqk</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Albanian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00014</td>
+<td class="col-language-abbreviation">AlbSL</td>
+<td class="col-glottocode">alba1271</td>
+<td class="col-iso-639-3">sqk</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>38</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">38</td>
+<td class="col-handshapes">38</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00015.html
+++ b/docs/languages/lan00015.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Argentine Sign Language</title>
+  <title>Language: Argentine Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Argentine Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00015</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Argentine Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LSA</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>arge1236</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>aed</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>South America</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Argentine Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00015</td>
+<td class="col-language-abbreviation">LSA</td>
+<td class="col-glottocode">arge1236</td>
+<td class="col-iso-639-3">aed</td>
+<td class="col-macro-area">South America</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>88</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">88</td>
+<td class="col-handshapes">88</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00016.html
+++ b/docs/languages/lan00016.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Austrian Sign Language</title>
+  <title>Language: Austrian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Austrian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00016</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Austrian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>ÖGS</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>aust1252</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>asq</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Austrian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00016</td>
+<td class="col-language-abbreviation">ÖGS</td>
+<td class="col-glottocode">aust1252</td>
+<td class="col-iso-639-3">asq</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00016.html">ÖGS (SP_29)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>4</td>
+<td class="col-inventory"><a href="../inventories/inv00016.html">ÖGS (SP_29)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">4</td>
+<td class="col-handshapes">4</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00017.html
+++ b/docs/languages/lan00017.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>French Belgian Sign Language (Langue des signes de Belgique Francophone)</title>
+  <title>Language: French Belgian Sign Language (Langue des signes de Belgique Francophone)</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>French Belgian Sign Language (Langue des signes de Belgique Francophone)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00017</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LSFB</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>lang1248</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>sfb</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: French Belgian Sign Language <span class="title-extra">(Langue des signes de Belgique Francophone)</span></h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00017</td>
+<td class="col-language-abbreviation">LSFB</td>
+<td class="col-glottocode">lang1248</td>
+<td class="col-iso-639-3">sfb</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>105</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">105</td>
+<td class="col-handshapes">105</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00018.html
+++ b/docs/languages/lan00018.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Flemish Sign Language (Vlaamse Gebarentaal)</title>
+  <title>Language: Flemish Sign Language (Vlaamse Gebarentaal)</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Flemish Sign Language (Vlaamse Gebarentaal)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00018</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>VGT</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>vlaa1235</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>vgt</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Flemish Sign Language <span class="title-extra">(Vlaamse Gebarentaal)</span></h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00018</td>
+<td class="col-language-abbreviation">VGT</td>
+<td class="col-glottocode">vlaa1235</td>
+<td class="col-iso-639-3">vgt</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>137</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">137</td>
+<td class="col-handshapes">137</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00019.html
+++ b/docs/languages/lan00019.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Bulgarian Sign Language</title>
+  <title>Language: Bulgarian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Bulgarian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00019</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Bulgarian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>BZhE</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>bulg1240</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>bqn</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Bulgarian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00019</td>
+<td class="col-language-abbreviation">BZhE</td>
+<td class="col-glottocode">bulg1240</td>
+<td class="col-iso-639-3">bqn</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00020.html">BZhE (SP_134)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>3</td>
+<td class="col-inventory"><a href="../inventories/inv00020.html">BZhE (SP_134)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">3</td>
+<td class="col-handshapes">3</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00020.html
+++ b/docs/languages/lan00020.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Bolivian Sign Language</title>
+  <title>Language: Bolivian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Bolivian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00020</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Bolivian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LSB</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>boli1236</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>bvl</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>South America</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Bolivian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00020</td>
+<td class="col-language-abbreviation">LSB</td>
+<td class="col-glottocode">boli1236</td>
+<td class="col-iso-639-3">bvl</td>
+<td class="col-macro-area">South America</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00021.html">LSB (SP_45)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>6</td>
+<td class="col-inventory"><a href="../inventories/inv00021.html">LSB (SP_45)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">6</td>
+<td class="col-handshapes">6</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00021.html
+++ b/docs/languages/lan00021.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Brazilian Sign Language</title>
+  <title>Language: Brazilian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Brazilian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00021</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Brazilian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>Libras</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>braz1236</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>bzs</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>South America</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Brazilian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00021</td>
+<td class="col-language-abbreviation">Libras</td>
+<td class="col-glottocode">braz1236</td>
+<td class="col-iso-639-3">bzs</td>
+<td class="col-macro-area">South America</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>247</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">247</td>
+<td class="col-handshapes">247</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00022.html
+++ b/docs/languages/lan00022.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Quebec Sign Language</title>
+  <title>Language: Quebec Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Quebec Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00022</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Quebec Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LSQ</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>queb1245</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>fcs</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>North America</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Quebec Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00022</td>
+<td class="col-language-abbreviation">LSQ</td>
+<td class="col-glottocode">queb1245</td>
+<td class="col-iso-639-3">fcs</td>
+<td class="col-macro-area">North America</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>159</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">159</td>
+<td class="col-handshapes">159</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00023.html
+++ b/docs/languages/lan00023.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Swiss-German Sign Language</title>
+  <title>Language: Swiss-German Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Swiss-German Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00023</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Swiss-German Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>DSGS</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>swis1240</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>sgg</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Swiss-German Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00023</td>
+<td class="col-language-abbreviation">DSGS</td>
+<td class="col-glottocode">swis1240</td>
+<td class="col-iso-639-3">sgg</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>85</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">85</td>
+<td class="col-handshapes">85</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00024.html
+++ b/docs/languages/lan00024.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Swiss-French Sign Language</title>
+  <title>Language: Swiss-French Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Swiss-French Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00024</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Swiss-French Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LSF-SR</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>swis1241</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>ssr</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Swiss-French Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00024</td>
+<td class="col-language-abbreviation">LSF-SR</td>
+<td class="col-glottocode">swis1241</td>
+<td class="col-iso-639-3">ssr</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>149</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">149</td>
+<td class="col-handshapes">149</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00025.html
+++ b/docs/languages/lan00025.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Swiss-Italian Sign Language</title>
+  <title>Language: Swiss-Italian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Swiss-Italian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00025</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Swiss-Italian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LIS-SI</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>swis1235</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>slf</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Swiss-Italian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00025</td>
+<td class="col-language-abbreviation">LIS-SI</td>
+<td class="col-glottocode">swis1235</td>
+<td class="col-iso-639-3">slf</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00027.html">LIS-SI (SP_50)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>3</td>
+<td class="col-inventory"><a href="../inventories/inv00027.html">LIS-SI (SP_50)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">3</td>
+<td class="col-handshapes">3</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00026.html
+++ b/docs/languages/lan00026.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Chilean Sign Language</title>
+  <title>Language: Chilean Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Chilean Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00026</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Chilean Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LSCh</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>chil1264</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>csg</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>South America</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Chilean Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00026</td>
+<td class="col-language-abbreviation">LSCh</td>
+<td class="col-glottocode">chil1264</td>
+<td class="col-iso-639-3">csg</td>
+<td class="col-macro-area">South America</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>42</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">42</td>
+<td class="col-handshapes">42</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00027.html
+++ b/docs/languages/lan00027.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Colombian Sign Language</title>
+  <title>Language: Colombian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Colombian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00027</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Colombian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LSC (CO)</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>colo1249</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>csn</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>South America</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Colombian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00027</td>
+<td class="col-language-abbreviation">LSC (CO)</td>
+<td class="col-glottocode">colo1249</td>
+<td class="col-iso-639-3">csn</td>
+<td class="col-macro-area">South America</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>129</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">129</td>
+<td class="col-handshapes">129</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00028.html
+++ b/docs/languages/lan00028.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Costa Rican Sign Language</title>
+  <title>Language: Costa Rican Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Costa Rican Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00028</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Costa Rican Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LESCO</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>cost1249</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>csr</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>North America</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Costa Rican Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00028</td>
+<td class="col-language-abbreviation">LESCO</td>
+<td class="col-glottocode">cost1249</td>
+<td class="col-iso-639-3">csr</td>
+<td class="col-macro-area">North America</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00031.html">LESCO (SP_101)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>2</td>
+<td class="col-inventory"><a href="../inventories/inv00031.html">LESCO (SP_101)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">2</td>
+<td class="col-handshapes">2</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00029.html
+++ b/docs/languages/lan00029.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Czech Sign Language</title>
+  <title>Language: Czech Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Czech Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00029</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Czech Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>ČZJ</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>czec1253</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>cse</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Czech Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00029</td>
+<td class="col-language-abbreviation">ČZJ</td>
+<td class="col-glottocode">czec1253</td>
+<td class="col-iso-639-3">cse</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>122</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">122</td>
+<td class="col-handshapes">122</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00030.html
+++ b/docs/languages/lan00030.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Ecuadorian Sign Language</title>
+  <title>Language: Ecuadorian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Ecuadorian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00030</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Ecuadorian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LSEC</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>ecua1243</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>ecs</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>South America</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Ecuadorian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00030</td>
+<td class="col-language-abbreviation">LSEC</td>
+<td class="col-glottocode">ecua1243</td>
+<td class="col-iso-639-3">ecs</td>
+<td class="col-macro-area">South America</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00035.html">LSEC (SP_136)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>3</td>
+<td class="col-inventory"><a href="../inventories/inv00035.html">LSEC (SP_136)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">3</td>
+<td class="col-handshapes">3</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00031.html
+++ b/docs/languages/lan00031.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Estonian Sign Language</title>
+  <title>Language: Estonian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Estonian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00031</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Estonian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>EVK</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>esto1238</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>eso</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Estonian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00031</td>
+<td class="col-language-abbreviation">EVK</td>
+<td class="col-glottocode">esto1238</td>
+<td class="col-iso-639-3">eso</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00036.html">EVK (SP_109)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>3</td>
+<td class="col-inventory"><a href="../inventories/inv00036.html">EVK (SP_109)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">3</td>
+<td class="col-handshapes">3</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00032.html
+++ b/docs/languages/lan00032.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Egypt Sign Language</title>
+  <title>Language: Egypt Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Egypt Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00032</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Egypt Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>ESL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>egyp1238</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>esl</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Africa</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Egypt Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00032</td>
+<td class="col-language-abbreviation">ESL</td>
+<td class="col-glottocode">egyp1238</td>
+<td class="col-iso-639-3">esl</td>
+<td class="col-macro-area">Africa</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00037.html">ESL (SP_84)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>3</td>
+<td class="col-inventory"><a href="../inventories/inv00037.html">ESL (SP_84)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">3</td>
+<td class="col-handshapes">3</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00033.html
+++ b/docs/languages/lan00033.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Spanish Sign Language</title>
+  <title>Language: Spanish Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Spanish Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00033</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Spanish Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LSE</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>span1263</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>ssp</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Spanish Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00033</td>
+<td class="col-language-abbreviation">LSE</td>
+<td class="col-glottocode">span1263</td>
+<td class="col-iso-639-3">ssp</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>140</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">140</td>
+<td class="col-handshapes">140</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00034.html
+++ b/docs/languages/lan00034.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Catalan Sign Language</title>
+  <title>Language: Catalan Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Catalan Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00034</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Catalan Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LSC (CT)</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>cata1241</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>csc</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Catalan Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00034</td>
+<td class="col-language-abbreviation">LSC (CT)</td>
+<td class="col-glottocode">cata1241</td>
+<td class="col-iso-639-3">csc</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>126</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">126</td>
+<td class="col-handshapes">126</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00035.html
+++ b/docs/languages/lan00035.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Ethiopian Sign Language</title>
+  <title>Language: Ethiopian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Ethiopian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00035</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Ethiopian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>EthSL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>ethi1238</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>eth</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Africa</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Ethiopian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00035</td>
+<td class="col-language-abbreviation">EthSL</td>
+<td class="col-glottocode">ethi1238</td>
+<td class="col-iso-639-3">eth</td>
+<td class="col-macro-area">Africa</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>52</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">52</td>
+<td class="col-handshapes">52</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00036.html
+++ b/docs/languages/lan00036.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Finnish Sign Language</title>
+  <title>Language: Finnish Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Finnish Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00036</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Finnish Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>FinSL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>finn1310</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>fse</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Finnish Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00036</td>
+<td class="col-language-abbreviation">FinSL</td>
+<td class="col-glottocode">finn1310</td>
+<td class="col-iso-639-3">fse</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>40</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">40</td>
+<td class="col-handshapes">40</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00037.html
+++ b/docs/languages/lan00037.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>French Sign Language</title>
+  <title>Language: French Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>French Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00037</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>French Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LSF</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>fren1243</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>fsl</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: French Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00037</td>
+<td class="col-language-abbreviation">LSF</td>
+<td class="col-glottocode">fren1243</td>
+<td class="col-iso-639-3">fsl</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>82</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">82</td>
+<td class="col-handshapes">82</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00038.html
+++ b/docs/languages/lan00038.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</title>
+  <title>Language: Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00038</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>NISLs</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>brit1235, iris1235</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>bfi, isg</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Northern Irish Sign Languages <span class="title-extra">(British Sign Language, Irish Sign Language)</span></h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00038</td>
+<td class="col-language-abbreviation">NISLs</td>
+<td class="col-glottocode">brit1235<br>iris1235</td>
+<td class="col-iso-639-3">bfi<br>isg</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>22</td>
+<td class="col-inventory"><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">22</td>
+<td class="col-handshapes">22</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00039.html
+++ b/docs/languages/lan00039.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Greek Sign Language</title>
+  <title>Language: Greek Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Greek Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00039</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Greek Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>ENG</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>gree1271</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>gss</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Greek Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00039</td>
+<td class="col-language-abbreviation">ENG</td>
+<td class="col-glottocode">gree1271</td>
+<td class="col-iso-639-3">gss</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>18</td>
+<td class="col-inventory"><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">18</td>
+<td class="col-handshapes">18</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00040.html
+++ b/docs/languages/lan00040.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Guatemalan Sign Language</title>
+  <title>Language: Guatemalan Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Guatemalan Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00040</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Guatemalan Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>Lensegua</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>guat1249</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>gsm</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>North America</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Guatemalan Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00040</td>
+<td class="col-language-abbreviation">Lensegua</td>
+<td class="col-glottocode">guat1249</td>
+<td class="col-iso-639-3">gsm</td>
+<td class="col-macro-area">North America</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00046.html">Lensegua (SP_112)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>3</td>
+<td class="col-inventory"><a href="../inventories/inv00046.html">Lensegua (SP_112)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">3</td>
+<td class="col-handshapes">3</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00041.html
+++ b/docs/languages/lan00041.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Honduras Sign Language</title>
+  <title>Language: Honduras Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Honduras Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00041</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Honduras Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LESHO</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>hond1239</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>hds</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>North America</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Honduras Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00041</td>
+<td class="col-language-abbreviation">LESHO</td>
+<td class="col-glottocode">hond1239</td>
+<td class="col-iso-639-3">hds</td>
+<td class="col-macro-area">North America</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>135</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">135</td>
+<td class="col-handshapes">135</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00042.html
+++ b/docs/languages/lan00042.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Haitian Sign Language</title>
+  <title>Language: Haitian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Haitian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00042</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Haitian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LSH</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>hait1245</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>(none)</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>North America</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Haitian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00042</td>
+<td class="col-language-abbreviation">LSH</td>
+<td class="col-glottocode">hait1245</td>
+<td class="col-iso-639-3">(none)</td>
+<td class="col-macro-area">North America</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00049.html">LSH (SP_113)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>3</td>
+<td class="col-inventory"><a href="../inventories/inv00049.html">LSH (SP_113)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">3</td>
+<td class="col-handshapes">3</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00043.html
+++ b/docs/languages/lan00043.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Hungarian Sign Language</title>
+  <title>Language: Hungarian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Hungarian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00043</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Hungarian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>HSL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>hung1263</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>hsh</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Hungarian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00043</td>
+<td class="col-language-abbreviation">HSL</td>
+<td class="col-glottocode">hung1263</td>
+<td class="col-iso-639-3">hsh</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>20</td>
+<td class="col-inventory"><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">20</td>
+<td class="col-handshapes">20</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00044.html
+++ b/docs/languages/lan00044.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Irish Sign Language</title>
+  <title>Language: Irish Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Irish Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00044</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Irish Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>ISL (IE)</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>iris1235</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>isg</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Irish Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00044</td>
+<td class="col-language-abbreviation">ISL (IE)</td>
+<td class="col-glottocode">iris1235</td>
+<td class="col-iso-639-3">isg</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>38</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">38</td>
+<td class="col-handshapes">38</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00045.html
+++ b/docs/languages/lan00045.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Israeli Sign Language</title>
+  <title>Language: Israeli Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Israeli Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00045</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Israeli Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>Shassi, ISL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>isra1236</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>isr</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Israeli Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00045</td>
+<td class="col-language-abbreviation">Shassi, ISL</td>
+<td class="col-glottocode">isra1236</td>
+<td class="col-iso-639-3">isr</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>21</td>
+<td class="col-inventory"><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">21</td>
+<td class="col-handshapes">21</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00046.html
+++ b/docs/languages/lan00046.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Indian Sign Language</title>
+  <title>Language: Indian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Indian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00046</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Indian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>ISL (IN)</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>indi1237</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>ins</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Indian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00046</td>
+<td class="col-language-abbreviation">ISL (IN)</td>
+<td class="col-glottocode">indi1237</td>
+<td class="col-iso-639-3">ins</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00053.html">ISL (IN) (SP_85)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>1</td>
+<td class="col-inventory"><a href="../inventories/inv00053.html">ISL (IN) (SP_85)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">1</td>
+<td class="col-handshapes">1</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00047.html
+++ b/docs/languages/lan00047.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Icelandic Sign Language</title>
+  <title>Language: Icelandic Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Icelandic Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00047</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Icelandic Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>ÍTM</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>icel1236</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>icl</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Icelandic Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00047</td>
+<td class="col-language-abbreviation">ÍTM</td>
+<td class="col-glottocode">icel1236</td>
+<td class="col-iso-639-3">icl</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>17</td>
+<td class="col-inventory"><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">17</td>
+<td class="col-handshapes">17</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00048.html
+++ b/docs/languages/lan00048.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Italian Sign Language</title>
+  <title>Language: Italian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Italian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00048</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Italian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LIS</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>ital1275</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>ise</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Italian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00048</td>
+<td class="col-language-abbreviation">LIS</td>
+<td class="col-glottocode">ital1275</td>
+<td class="col-iso-639-3">ise</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>89</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">89</td>
+<td class="col-handshapes">89</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00049.html
+++ b/docs/languages/lan00049.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Jordanian Sign Language or Levantine Arabic Sign Language</title>
+  <title>Language: Jordanian Sign Language or Levantine Arabic Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Jordanian Sign Language or Levantine Arabic Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00049</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Jordanian Sign Language or Levantine Arabic Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LIU</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>jord1238</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>jos</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Jordanian Sign Language or Levantine Arabic Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00049</td>
+<td class="col-language-abbreviation">LIU</td>
+<td class="col-glottocode">jord1238</td>
+<td class="col-iso-639-3">jos</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>15</td>
+<td class="col-inventory"><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">15</td>
+<td class="col-handshapes">15</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00050.html
+++ b/docs/languages/lan00050.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Japanese Sign Language</title>
+  <title>Language: Japanese Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Japanese Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00050</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Japanese Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>JSL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>japa1238</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>jsl</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Japanese Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00050</td>
+<td class="col-language-abbreviation">JSL</td>
+<td class="col-glottocode">japa1238</td>
+<td class="col-iso-639-3">jsl</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>58</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">58</td>
+<td class="col-handshapes">58</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00051.html
+++ b/docs/languages/lan00051.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Kenya-Somali Sign Language</title>
+  <title>Language: Kenya-Somali Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Kenya-Somali Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00051</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Kenya-Somali Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>KSL, LAK</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>keny1241</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>xki</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Africa</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Kenya-Somali Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00051</td>
+<td class="col-language-abbreviation">KSL, LAK</td>
+<td class="col-glottocode">keny1241</td>
+<td class="col-iso-639-3">xki</td>
+<td class="col-macro-area">Africa</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00058.html">KSL, LAK (SP_79)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>10</td>
+<td class="col-inventory"><a href="../inventories/inv00058.html">KSL, LAK (SP_79)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">10</td>
+<td class="col-handshapes">10</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00052.html
+++ b/docs/languages/lan00052.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Lithuanian Sign Language</title>
+  <title>Language: Lithuanian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Lithuanian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00052</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Lithuanian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LGK</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>lith1236</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>lls</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Lithuanian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00052</td>
+<td class="col-language-abbreviation">LGK</td>
+<td class="col-glottocode">lith1236</td>
+<td class="col-iso-639-3">lls</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00060.html">LGK (SP_107)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>3</td>
+<td class="col-inventory"><a href="../inventories/inv00060.html">LGK (SP_107)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">3</td>
+<td class="col-handshapes">3</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00053.html
+++ b/docs/languages/lan00053.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Latvian Sign Language</title>
+  <title>Language: Latvian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Latvian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00053</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Latvian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LSL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>latv1245</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>lsl</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Latvian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00053</td>
+<td class="col-language-abbreviation">LSL</td>
+<td class="col-glottocode">latv1245</td>
+<td class="col-iso-639-3">lsl</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00061.html">LSL (SP_108)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>3</td>
+<td class="col-inventory"><a href="../inventories/inv00061.html">LSL (SP_108)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">3</td>
+<td class="col-handshapes">3</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00054.html
+++ b/docs/languages/lan00054.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</title>
+  <title>Language: Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00054</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>MSLs</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>mand1477, yang1309</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>(none), ysm</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Myanmar Sign Languages or Burmese Sign Languages <span class="title-extra">(Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</span></h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00054</td>
+<td class="col-language-abbreviation">MSLs</td>
+<td class="col-glottocode">mand1477<br>yang1309</td>
+<td class="col-iso-639-3">(none)<br>ysm</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>130</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">130</td>
+<td class="col-handshapes">130</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00055.html
+++ b/docs/languages/lan00055.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Maltese Sign Language</title>
+  <title>Language: Maltese Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Maltese Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00055</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Maltese Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LSM (MT)</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>malt1238</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>mdl</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Maltese Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00055</td>
+<td class="col-language-abbreviation">LSM (MT)</td>
+<td class="col-glottocode">malt1238</td>
+<td class="col-iso-639-3">mdl</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>130</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">130</td>
+<td class="col-handshapes">130</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00056.html
+++ b/docs/languages/lan00056.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Malawian Sign Language</title>
+  <title>Language: Malawian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Malawian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00056</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Malawian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>MSL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>mala1549</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>lws</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Africa</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Malawian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00056</td>
+<td class="col-language-abbreviation">MSL</td>
+<td class="col-glottocode">mala1549</td>
+<td class="col-iso-639-3">lws</td>
+<td class="col-macro-area">Africa</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>31</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">31</td>
+<td class="col-handshapes">31</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00057.html
+++ b/docs/languages/lan00057.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Mexican Sign Language</title>
+  <title>Language: Mexican Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Mexican Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00057</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Mexican Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LSM (MX)</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>mexi1237</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>mfs</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>North America</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Mexican Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00057</td>
+<td class="col-language-abbreviation">LSM (MX)</td>
+<td class="col-glottocode">mexi1237</td>
+<td class="col-iso-639-3">mfs</td>
+<td class="col-macro-area">North America</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>122</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">122</td>
+<td class="col-handshapes">122</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00058.html
+++ b/docs/languages/lan00058.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Malaysian Sign Language</title>
+  <title>Language: Malaysian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Malaysian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00058</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Malaysian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>BIM</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>mala1412</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>xml</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Malaysian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00058</td>
+<td class="col-language-abbreviation">BIM</td>
+<td class="col-glottocode">mala1412</td>
+<td class="col-iso-639-3">xml</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00065.html">BIM (SP_66)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>2</td>
+<td class="col-inventory"><a href="../inventories/inv00065.html">BIM (SP_66)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">2</td>
+<td class="col-handshapes">2</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00059.html
+++ b/docs/languages/lan00059.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Nigerian Sign Language</title>
+  <title>Language: Nigerian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Nigerian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00059</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Nigerian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>NSL (NG)</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>nige1240</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>nsi</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Africa</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Nigerian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00059</td>
+<td class="col-language-abbreviation">NSL (NG)</td>
+<td class="col-glottocode">nige1240</td>
+<td class="col-iso-639-3">nsi</td>
+<td class="col-macro-area">Africa</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00066.html">NSL (NG) (SP_32)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>6</td>
+<td class="col-inventory"><a href="../inventories/inv00066.html">NSL (NG) (SP_32)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">6</td>
+<td class="col-handshapes">6</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00060.html
+++ b/docs/languages/lan00060.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Nicaraguan Sign Language</title>
+  <title>Language: Nicaraguan Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Nicaraguan Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00060</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Nicaraguan Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>ISN</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>nica1238</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>ncs</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>North America</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Nicaraguan Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00060</td>
+<td class="col-language-abbreviation">ISN</td>
+<td class="col-glottocode">nica1238</td>
+<td class="col-iso-639-3">ncs</td>
+<td class="col-macro-area">North America</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>88</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">88</td>
+<td class="col-handshapes">88</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00061.html
+++ b/docs/languages/lan00061.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Norwegian Sign Language</title>
+  <title>Language: Norwegian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Norwegian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00061</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Norwegian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>NTS, NSL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>norw1255</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>nsl</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Norwegian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00061</td>
+<td class="col-language-abbreviation">NTS, NSL</td>
+<td class="col-glottocode">norw1255</td>
+<td class="col-iso-639-3">nsl</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>112</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">112</td>
+<td class="col-handshapes">112</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00062.html
+++ b/docs/languages/lan00062.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Nepalese Sign Language or Nepali Sign Language</title>
+  <title>Language: Nepalese Sign Language or Nepali Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Nepalese Sign Language or Nepali Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00062</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Nepalese Sign Language or Nepali Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>NSL (NP)</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>nepa1250</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>nsp</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Nepalese Sign Language or Nepali Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00062</td>
+<td class="col-language-abbreviation">NSL (NP)</td>
+<td class="col-glottocode">nepa1250</td>
+<td class="col-iso-639-3">nsp</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00070.html">NSL (NP) (SP_133)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>5</td>
+<td class="col-inventory"><a href="../inventories/inv00070.html">NSL (NP) (SP_133)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">5</td>
+<td class="col-handshapes">5</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00063.html
+++ b/docs/languages/lan00063.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Peruvian Sign Language</title>
+  <title>Language: Peruvian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Peruvian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00063</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Peruvian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LSP</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>peru1235</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>prl</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>South America</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Peruvian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00063</td>
+<td class="col-language-abbreviation">LSP</td>
+<td class="col-glottocode">peru1235</td>
+<td class="col-iso-639-3">prl</td>
+<td class="col-macro-area">South America</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>43</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">43</td>
+<td class="col-handshapes">43</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00064.html
+++ b/docs/languages/lan00064.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Philippine Sign Language</title>
+  <title>Language: Philippine Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Philippine Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00064</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Philippine Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>FSL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>phil1239</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>psp</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Papunesia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Philippine Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00064</td>
+<td class="col-language-abbreviation">FSL</td>
+<td class="col-glottocode">phil1239</td>
+<td class="col-iso-639-3">psp</td>
+<td class="col-macro-area">Papunesia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>85</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">85</td>
+<td class="col-handshapes">85</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00065.html
+++ b/docs/languages/lan00065.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Pakistan Sign Language</title>
+  <title>Language: Pakistan Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Pakistan Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00065</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Pakistan Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>PSL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>paki1242</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>pks</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Pakistan Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00065</td>
+<td class="col-language-abbreviation">PSL</td>
+<td class="col-glottocode">paki1242</td>
+<td class="col-iso-639-3">pks</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00074.html">PSL (SP_87)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>9</td>
+<td class="col-inventory"><a href="../inventories/inv00074.html">PSL (SP_87)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">9</td>
+<td class="col-handshapes">9</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00066.html
+++ b/docs/languages/lan00066.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Polish Sign Language</title>
+  <title>Language: Polish Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Polish Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00066</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Polish Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>PJM</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>poli1259</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>pso</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Polish Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00066</td>
+<td class="col-language-abbreviation">PJM</td>
+<td class="col-glottocode">poli1259</td>
+<td class="col-iso-639-3">pso</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>90</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">90</td>
+<td class="col-handshapes">90</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00067.html
+++ b/docs/languages/lan00067.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Portuguese Sign Language</title>
+  <title>Language: Portuguese Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Portuguese Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00067</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Portuguese Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LGP</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>port1277</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>psr</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Portuguese Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00067</td>
+<td class="col-language-abbreviation">LGP</td>
+<td class="col-glottocode">port1277</td>
+<td class="col-iso-639-3">psr</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>83</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">83</td>
+<td class="col-handshapes">83</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00068.html
+++ b/docs/languages/lan00068.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Paraguayan Sign Language</title>
+  <title>Language: Paraguayan Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Paraguayan Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00068</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Paraguayan Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LSPy</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>para1318</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>pys</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>South America</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Paraguayan Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00068</td>
+<td class="col-language-abbreviation">LSPy</td>
+<td class="col-glottocode">para1318</td>
+<td class="col-iso-639-3">pys</td>
+<td class="col-macro-area">South America</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>113</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">113</td>
+<td class="col-handshapes">113</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00069.html
+++ b/docs/languages/lan00069.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Romanian Sign Language</title>
+  <title>Language: Romanian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Romanian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00069</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Romanian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LSR</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>roma1324</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>rms</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Romanian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00069</td>
+<td class="col-language-abbreviation">LSR</td>
+<td class="col-glottocode">roma1324</td>
+<td class="col-iso-639-3">rms</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>19</td>
+<td class="col-inventory"><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">19</td>
+<td class="col-handshapes">19</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00070.html
+++ b/docs/languages/lan00070.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Russian-Tajik Sign Language</title>
+  <title>Language: Russian-Tajik Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Russian-Tajik Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00070</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Russian-Tajik Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>RSL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>russ1255</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>rsl</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Russian-Tajik Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00070</td>
+<td class="col-language-abbreviation">RSL</td>
+<td class="col-glottocode">russ1255</td>
+<td class="col-iso-639-3">rsl</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>57</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">57</td>
+<td class="col-handshapes">57</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00071.html
+++ b/docs/languages/lan00071.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Saudi Sign Language or Saudi Arabian Sign Language</title>
+  <title>Language: Saudi Sign Language or Saudi Arabian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Saudi Sign Language or Saudi Arabian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00071</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>SSL, SASL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>saud1238</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>sdl</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Saudi Sign Language or Saudi Arabian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00071</td>
+<td class="col-language-abbreviation">SSL, SASL</td>
+<td class="col-glottocode">saud1238</td>
+<td class="col-iso-639-3">sdl</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>79</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">79</td>
+<td class="col-handshapes">79</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00072.html
+++ b/docs/languages/lan00072.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Singapore Sign Language</title>
+  <title>Language: Singapore Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Singapore Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00072</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Singapore Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>SgSL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>sing1237</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>sls</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Singapore Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00072</td>
+<td class="col-language-abbreviation">SgSL</td>
+<td class="col-glottocode">sing1237</td>
+<td class="col-iso-639-3">sls</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>91</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">91</td>
+<td class="col-handshapes">91</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00073.html
+++ b/docs/languages/lan00073.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Slovakian Sign Language</title>
+  <title>Language: Slovakian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Slovakian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00073</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Slovakian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>SPJ</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>slov1263</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>svk</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Slovakian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00073</td>
+<td class="col-language-abbreviation">SPJ</td>
+<td class="col-glottocode">slov1263</td>
+<td class="col-iso-639-3">svk</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00083.html">SPJ (SP_89)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>3</td>
+<td class="col-inventory"><a href="../inventories/inv00083.html">SPJ (SP_89)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">3</td>
+<td class="col-handshapes">3</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00074.html
+++ b/docs/languages/lan00074.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Salvadoran Sign Language</title>
+  <title>Language: Salvadoran Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Salvadoran Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00074</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Salvadoran Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LESSA</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>salv1237</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>esn</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>North America</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Salvadoran Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00074</td>
+<td class="col-language-abbreviation">LESSA</td>
+<td class="col-glottocode">salv1237</td>
+<td class="col-iso-639-3">esn</td>
+<td class="col-macro-area">North America</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00084.html">LESSA (SP_137)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>1</td>
+<td class="col-inventory"><a href="../inventories/inv00084.html">LESSA (SP_137)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">1</td>
+<td class="col-handshapes">1</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00075.html
+++ b/docs/languages/lan00075.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Thai Sign Language</title>
+  <title>Language: Thai Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Thai Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00075</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Thai Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>TSL, MSTSL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>thai1240</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>tsq</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Thai Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00075</td>
+<td class="col-language-abbreviation">TSL, MSTSL</td>
+<td class="col-glottocode">thai1240</td>
+<td class="col-iso-639-3">tsq</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>95</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">95</td>
+<td class="col-handshapes">95</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00076.html
+++ b/docs/languages/lan00076.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Tunisian Sign Language</title>
+  <title>Language: Tunisian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Tunisian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00076</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Tunisian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>TunSL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>tuni1249</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>tse</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Africa</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Tunisian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00076</td>
+<td class="col-language-abbreviation">TunSL</td>
+<td class="col-glottocode">tuni1249</td>
+<td class="col-iso-639-3">tse</td>
+<td class="col-macro-area">Africa</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>165</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">165</td>
+<td class="col-handshapes">165</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00077.html
+++ b/docs/languages/lan00077.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Turkish Sign Language</title>
+  <title>Language: Turkish Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Turkish Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00077</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Turkish Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>TİD</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>turk1288</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>tsm</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Turkish Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00077</td>
+<td class="col-language-abbreviation">TİD</td>
+<td class="col-glottocode">turk1288</td>
+<td class="col-iso-639-3">tsm</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00087.html">TİD (SP_90)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>1</td>
+<td class="col-inventory"><a href="../inventories/inv00087.html">TİD (SP_90)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">1</td>
+<td class="col-handshapes">1</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00078.html
+++ b/docs/languages/lan00078.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Ukrainian Sign Language</title>
+  <title>Language: Ukrainian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Ukrainian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00078</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Ukrainian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>USL, UZhM</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>ukra1235</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>ukl</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Ukrainian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00078</td>
+<td class="col-language-abbreviation">USL, UZhM</td>
+<td class="col-glottocode">ukra1235</td>
+<td class="col-iso-639-3">ukl</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>72</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">72</td>
+<td class="col-handshapes">72</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00079.html
+++ b/docs/languages/lan00079.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Uruguayan Sign Language</title>
+  <title>Language: Uruguayan Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Uruguayan Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00079</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Uruguayan Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>LSU</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>urug1238</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>ugy</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>South America</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Uruguayan Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00079</td>
+<td class="col-language-abbreviation">LSU</td>
+<td class="col-glottocode">urug1238</td>
+<td class="col-iso-639-3">ugy</td>
+<td class="col-macro-area">South America</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>72</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">72</td>
+<td class="col-handshapes">72</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00080.html
+++ b/docs/languages/lan00080.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Venezuelan Sign Language</title>
+  <title>Language: Venezuelan Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Venezuelan Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00080</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Venezuelan Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>VSL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>vene1237</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>vsl</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>South America</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Venezuelan Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00080</td>
+<td class="col-language-abbreviation">VSL</td>
+<td class="col-glottocode">vene1237</td>
+<td class="col-iso-639-3">vsl</td>
+<td class="col-macro-area">South America</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>45</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">45</td>
+<td class="col-handshapes">45</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00081.html
+++ b/docs/languages/lan00081.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</title>
+  <title>Language: Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00081</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>VSLs</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>haip1238, hano1243, hoch1237</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>haf, hab, hos</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Vietnamese Sign Languages <span class="title-extra">(Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</span></h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00081</td>
+<td class="col-language-abbreviation">VSLs</td>
+<td class="col-glottocode">haip1238<br>hano1243<br>hoch1237</td>
+<td class="col-iso-639-3">haf<br>hab<br>hos</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>55</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">55</td>
+<td class="col-handshapes">55</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00082.html
+++ b/docs/languages/lan00082.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>International Sign</title>
+  <title>Language: International Sign</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>International Sign</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00082</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>International Sign</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>IS</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>inte1259</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>ils</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: International Sign</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00082</td>
+<td class="col-language-abbreviation">IS</td>
+<td class="col-glottocode">inte1259</td>
+<td class="col-iso-639-3">ils</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>55</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">55</td>
+<td class="col-handshapes">55</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00083.html
+++ b/docs/languages/lan00083.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>South African Sign Language</title>
+  <title>Language: South African Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>South African Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00083</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>South African Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>SASL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>sout1404</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>sfs</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Africa</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: South African Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00083</td>
+<td class="col-language-abbreviation">SASL</td>
+<td class="col-glottocode">sout1404</td>
+<td class="col-iso-639-3">sfs</td>
+<td class="col-macro-area">Africa</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>63</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">63</td>
+<td class="col-handshapes">63</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00084.html
+++ b/docs/languages/lan00084.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Esperanto-SignUno</title>
+  <title>Language: Esperanto-SignUno</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Esperanto-SignUno</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00084</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Esperanto-SignUno</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>Signuno</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>(none)</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>(none)</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>(none)</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Esperanto-SignUno</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00084</td>
+<td class="col-language-abbreviation">Signuno</td>
+<td class="col-glottocode">(none)</td>
+<td class="col-iso-639-3">(none)</td>
+<td class="col-macro-area">(none)</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>45</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">45</td>
+<td class="col-handshapes">45</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/languages/lan00085.html
+++ b/docs/languages/lan00085.html
@@ -3,53 +3,274 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Yugoslavian Sign Language</title>
+  <title>Language: Yugoslavian Sign Language</title>
+  
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+
 </head>
 <body>
-  <h1>Yugoslavian Sign Language</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Language Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Language Id</th>
-<td>lan00085</td>
-</tr>
-<tr>
-<th>Language Name</th>
-<td>Yugoslavian Sign Language</td>
-</tr>
-<tr>
-<th>Language Abbreviation</th>
-<td>YSL</td>
-</tr>
-<tr>
-<th>Glottocode</th>
-<td>(none)</td>
-</tr>
-<tr>
-<th>Iso-639-3</th>
-<td>(none)</td>
-</tr>
-<tr>
-<th>Macro-Area</th>
-<td>Eurasia</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1 class="language-title">Language: Yugoslavian Sign Language</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Source</th>
-<th>Segments</th>
+<th class="col-language-id">Language Id</th>
+<th class="col-language-abbreviation">Language Abbreviation</th>
+<th class="col-glottocode">Glottocode</th>
+<th class="col-iso-639-3">ISO 639-3</th>
+<th class="col-macro-area">Macro-Area</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-language-id">lan00085</td>
+<td class="col-language-abbreviation">YSL</td>
+<td class="col-glottocode">(none)</td>
+<td class="col-iso-639-3">(none)</td>
+<td class="col-macro-area">Eurasia</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists all the inventories associated with the specified sign language(s).</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-source">Source</th>
+<th class="col-segments">Segments<br><span>Total</span></th>
+<th class="col-handshapes">Handshapes<br><span>Count</span></th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Luz Diaz (2025)</td>
-<td>111</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-source">Luz Diaz (2025)</td>
+<td class="col-segments">111</td>
+<td class="col-handshapes">111</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00001.html
+++ b/docs/segments/seg00001.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1f5</title>
+  <title>Segment: Handshape S1f5</title>
   
 <style>
 @font-face {
@@ -12,423 +12,637 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1f5</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00001</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>0_finger(Fist)</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1f5</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅯣</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting">񅯡</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1f5</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00001</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S1f5</td>
+<td class="signwriting col-signwriting-1">񅯣</td>
+<td class="signwriting col-signwriting-2">񅯡</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00013.html">AFSL (SP_106)</a></td>
-<td>Afghan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00013.html">AFSL (SP_106)</a></td>
+<td class="col-language">Afghan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00021.html">LSB (SP_45)</a></td>
-<td>Bolivian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00021.html">LSB (SP_45)</a></td>
+<td class="col-language">Bolivian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00053.html">ISL (IN) (SP_85)</a></td>
-<td>Indian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00053.html">ISL (IN) (SP_85)</a></td>
+<td class="col-language">Indian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
-<td>Icelandic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
+<td class="col-language">Icelandic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
-<td>Jordanian Sign Language or Levantine Arabic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
+<td class="col-language">Jordanian Sign Language or Levantine Arabic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
-<td>Romanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
+<td class="col-language">Romanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00002.html
+++ b/docs/segments/seg00002.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1f7</title>
+  <title>Segment: Handshape S1f7</title>
   
 <style>
 @font-face {
@@ -12,363 +12,577 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1f7</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00002</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>0_finger(Fist)</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1f7</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅲱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting">񅳁</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1f7</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00002</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S1f7</td>
+<td class="signwriting col-signwriting-1">񅲱</td>
+<td class="signwriting col-signwriting-2">񅳁</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
-<td>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
+<td class="col-language">Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
-<td>Greek Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
+<td class="col-language">Greek Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
-<td>Israeli Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
+<td class="col-language">Israeli Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
-<td>Icelandic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
+<td class="col-language">Icelandic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00003.html
+++ b/docs/segments/seg00003.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1f8</title>
+  <title>Segment: Handshape S1f8</title>
   
 <style>
 @font-face {
@@ -12,263 +12,477 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1f8</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00003</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>0_finger(Fist)</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1f8</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅴑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1f8</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00003</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S1f8</td>
+<td class="signwriting col-signwriting-1">񅴑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00004.html
+++ b/docs/segments/seg00004.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S203</title>
+  <title>Segment: Handshape S203</title>
   
 <style>
 @font-face {
@@ -12,133 +12,347 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S203</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00004</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>0_finger(Fist)</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S203</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񆄱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting">񆅁</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S203</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00004</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S203</td>
+<td class="signwriting col-signwriting-1">񆄱</td>
+<td class="signwriting col-signwriting-2">񆅁</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00005.html
+++ b/docs/segments/seg00005.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1f9</title>
+  <title>Segment: Handshape S1f9</title>
   
 <style>
 @font-face {
@@ -12,223 +12,437 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1f9</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00005</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>0_finger(Fist)</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers bent)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1f9</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅵱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1f9</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00005</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw">S1f9</td>
+<td class="signwriting col-signwriting-1">񅵱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00006.html
+++ b/docs/segments/seg00006.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1fb</title>
+  <title>Segment: Handshape S1fb</title>
   
 <style>
 @font-face {
@@ -12,238 +12,452 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1fb</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00006</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>0_finger(Fist)</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fistDerivation)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1fb</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅸱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1fb</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00006</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw">S1fb</td>
+<td class="signwriting col-signwriting-1">񅸱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00007.html
+++ b/docs/segments/seg00007.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1fc</title>
+  <title>Segment: Handshape S1fc</title>
   
 <style>
 @font-face {
@@ -12,118 +12,332 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1fc</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00007</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>0_finger(Fist)</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fistDerivation)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1fc</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅺡</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting">񅺑</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1fc</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00007</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw">S1fc</td>
+<td class="signwriting col-signwriting-1">񅺡</td>
+<td class="signwriting col-signwriting-2">񅺑</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
-<td>Israeli Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
+<td class="col-language">Israeli Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00008.html
+++ b/docs/segments/seg00008.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1fd</title>
+  <title>Segment: Handshape S1fd</title>
   
 <style>
 @font-face {
@@ -12,113 +12,327 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1fd</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00008</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>0_finger(Fist)</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fistDerivation)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1fd</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅼁</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting">񅻱</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1fd</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00008</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw">S1fd</td>
+<td class="signwriting col-signwriting-1">񅼁</td>
+<td class="signwriting col-signwriting-2">񅻱</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
-<td>Israeli Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
+<td class="col-language">Israeli Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00009.html
+++ b/docs/segments/seg00009.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1ff</title>
+  <title>Segment: Handshape S1ff</title>
   
 <style>
 @font-face {
@@ -12,98 +12,312 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1ff</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00009</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>0_finger(Fist)</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fistDerivation)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1ff</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅾱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1ff</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00009</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw">S1ff</td>
+<td class="signwriting col-signwriting-1">񅾱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00010.html
+++ b/docs/segments/seg00010.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S200</title>
+  <title>Segment: Handshape S200</title>
   
 <style>
 @font-face {
@@ -12,78 +12,292 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S200</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00010</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>0_finger(Fist)</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fistDerivation)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S200</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񆀑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S200</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00010</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw">S200</td>
+<td class="signwriting col-signwriting-1">񆀑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00011.html
+++ b/docs/segments/seg00011.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S201</title>
+  <title>Segment: Handshape S201</title>
   
 <style>
 @font-face {
@@ -12,88 +12,302 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S201</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00011</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>0_finger(Fist)</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fistDerivation)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S201</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񆁱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S201</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00011</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">0_finger(Fist)</td>
+<td class="col-hamnosys-3-handshape-modifications">(fistDerivation)</td>
+<td class="col-fsw">S201</td>
+<td class="signwriting col-signwriting-1">񆁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00012.html
+++ b/docs/segments/seg00012.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S100</title>
+  <title>Segment: Handshape S100</title>
   
 <style>
 @font-face {
@@ -12,468 +12,682 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S100</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00012</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1_finger</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S100</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀀁</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S100</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00012</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S100</td>
+<td class="signwriting col-signwriting-1">񀀁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00013.html">AFSL (SP_106)</a></td>
-<td>Afghan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00013.html">AFSL (SP_106)</a></td>
+<td class="col-language">Afghan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00016.html">ÖGS (SP_29)</a></td>
-<td>Austrian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00016.html">ÖGS (SP_29)</a></td>
+<td class="col-language">Austrian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
-<td>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
+<td class="col-language">Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
-<td>Greek Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
+<td class="col-language">Greek Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
-<td>Hungarian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
+<td class="col-language">Hungarian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
-<td>Israeli Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
+<td class="col-language">Israeli Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
-<td>Icelandic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
+<td class="col-language">Icelandic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
-<td>Jordanian Sign Language or Levantine Arabic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
+<td class="col-language">Jordanian Sign Language or Levantine Arabic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00058.html">KSL, LAK (SP_79)</a></td>
-<td>Kenya-Somali Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00058.html">KSL, LAK (SP_79)</a></td>
+<td class="col-language">Kenya-Somali Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00070.html">NSL (NP) (SP_133)</a></td>
-<td>Nepalese Sign Language or Nepali Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00070.html">NSL (NP) (SP_133)</a></td>
+<td class="col-language">Nepalese Sign Language or Nepali Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00074.html">PSL (SP_87)</a></td>
-<td>Pakistan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00074.html">PSL (SP_87)</a></td>
+<td class="col-language">Pakistan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
-<td>Romanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
+<td class="col-language">Romanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00087.html">TİD (SP_90)</a></td>
-<td>Turkish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00087.html">TİD (SP_90)</a></td>
+<td class="col-language">Turkish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00013.html
+++ b/docs/segments/seg00013.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S101</title>
+  <title>Segment: Handshape S101</title>
   
 <style>
 @font-face {
@@ -12,348 +12,562 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S101</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00013</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1_finger</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S101</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀁱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S101</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00013</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S101</td>
+<td class="signwriting col-signwriting-1">񀁱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
-<td>Greek Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
+<td class="col-language">Greek Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00074.html">PSL (SP_87)</a></td>
-<td>Pakistan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00074.html">PSL (SP_87)</a></td>
+<td class="col-language">Pakistan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00014.html
+++ b/docs/segments/seg00014.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S103</title>
+  <title>Segment: Handshape S103</title>
   
 <style>
 @font-face {
@@ -12,158 +12,372 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S103</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00014</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1_finger</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S103</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀄱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S103</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00014</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S103</td>
+<td class="signwriting col-signwriting-1">񀄱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00015.html
+++ b/docs/segments/seg00015.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S108</title>
+  <title>Segment: Handshape S108</title>
   
 <style>
 @font-face {
@@ -12,103 +12,317 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S108</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00015</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1_finger</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S108</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀌑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S108</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00015</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S108</td>
+<td class="signwriting col-signwriting-1">񀌑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00016.html
+++ b/docs/segments/seg00016.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S192</title>
+  <title>Segment: Handshape S192</title>
   
 <style>
 @font-face {
@@ -12,418 +12,632 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S192</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00016</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1_finger</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S192</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񃛑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting">񃛁</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S192</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00016</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S192</td>
+<td class="signwriting col-signwriting-1">񃛑</td>
+<td class="signwriting col-signwriting-2">񃛁</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00021.html">LSB (SP_45)</a></td>
-<td>Bolivian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00021.html">LSB (SP_45)</a></td>
+<td class="col-language">Bolivian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
-<td>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
+<td class="col-language">Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
-<td>Greek Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
+<td class="col-language">Greek Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
-<td>Israeli Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
+<td class="col-language">Israeli Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
-<td>Icelandic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
+<td class="col-language">Icelandic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00017.html
+++ b/docs/segments/seg00017.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S193</title>
+  <title>Segment: Handshape S193</title>
   
 <style>
 @font-face {
@@ -12,103 +12,317 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S193</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00017</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1_finger</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S193</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񃜱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S193</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00017</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S193</td>
+<td class="signwriting col-signwriting-1">񃜱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00018.html
+++ b/docs/segments/seg00018.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S19a</title>
+  <title>Segment: Handshape S19a</title>
   
 <style>
 @font-face {
@@ -12,403 +12,617 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S19a</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00018</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1_finger</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S19a</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񃧑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting">񃧁</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S19a</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00018</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S19a</td>
+<td class="signwriting col-signwriting-1">񃧑</td>
+<td class="signwriting col-signwriting-2">񃧁</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00027.html">LIS-SI (SP_50)</a></td>
-<td>Swiss-Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00027.html">LIS-SI (SP_50)</a></td>
+<td class="col-language">Swiss-Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
-<td>Greek Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
+<td class="col-language">Greek Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
-<td>Romanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
+<td class="col-language">Romanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00019.html
+++ b/docs/segments/seg00019.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1ae</title>
+  <title>Segment: Handshape S1ae</title>
   
 <style>
 @font-face {
@@ -12,118 +12,332 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1ae</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00019</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1_finger</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1ae</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񄅑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1ae</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00019</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S1ae</td>
+<td class="signwriting col-signwriting-1">񄅑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00020.html
+++ b/docs/segments/seg00020.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1c6</title>
+  <title>Segment: Handshape S1c6</title>
   
 <style>
 @font-face {
@@ -12,183 +12,397 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1c6</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00020</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1_finger</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1c6</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񄩁</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting">񄩑</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1c6</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00020</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S1c6</td>
+<td class="signwriting col-signwriting-1">񄩁</td>
+<td class="signwriting col-signwriting-2">񄩑</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
-<td>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
+<td class="col-language">Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00021.html
+++ b/docs/segments/seg00021.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1dc</title>
+  <title>Segment: Handshape S1dc</title>
   
 <style>
 @font-face {
@@ -12,423 +12,637 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1dc</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00021</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1_finger</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1dc</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅊑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting">񅊡</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1dc</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00021</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S1dc</td>
+<td class="signwriting col-signwriting-1">񅊑</td>
+<td class="signwriting col-signwriting-2">񅊡</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00027.html">LIS-SI (SP_50)</a></td>
-<td>Swiss-Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00027.html">LIS-SI (SP_50)</a></td>
+<td class="col-language">Swiss-Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
-<td>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
+<td class="col-language">Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
-<td>Greek Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
+<td class="col-language">Greek Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
-<td>Hungarian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
+<td class="col-language">Hungarian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
-<td>Israeli Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
+<td class="col-language">Israeli Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
-<td>Icelandic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
+<td class="col-language">Icelandic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
-<td>Romanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
+<td class="col-language">Romanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00022.html
+++ b/docs/segments/seg00022.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1de</title>
+  <title>Segment: Handshape S1de</title>
   
 <style>
 @font-face {
@@ -12,283 +12,497 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1de</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00022</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1_finger</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1de</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅍑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1de</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00022</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S1de</td>
+<td class="signwriting col-signwriting-1">񅍑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
-<td>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
+<td class="col-language">Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00023.html
+++ b/docs/segments/seg00023.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1df</title>
+  <title>Segment: Handshape S1df</title>
   
 <style>
 @font-face {
@@ -12,153 +12,367 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1df</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00023</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1_finger</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1df</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅎱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1df</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00023</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S1df</td>
+<td class="signwriting col-signwriting-1">񅎱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00024.html
+++ b/docs/segments/seg00024.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1e0</title>
+  <title>Segment: Handshape S1e0</title>
   
 <style>
 @font-face {
@@ -12,138 +12,352 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1e0</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00024</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1_finger</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1e0</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅐁</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting">񅐑</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1e0</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00024</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S1e0</td>
+<td class="signwriting col-signwriting-1">񅐁</td>
+<td class="signwriting col-signwriting-2">񅐑</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00025.html
+++ b/docs/segments/seg00025.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S10c</title>
+  <title>Segment: Handshape S10c</title>
   
 <style>
 @font-face {
@@ -12,238 +12,452 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S10c</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00025</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1_finger</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S10c</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀒑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S10c</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00025</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw">S10c</td>
+<td class="signwriting col-signwriting-1">񀒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
-<td>Hungarian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
+<td class="col-language">Hungarian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00026.html
+++ b/docs/segments/seg00026.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1f2</title>
+  <title>Segment: Handshape S1f2</title>
   
 <style>
 @font-face {
@@ -12,193 +12,407 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1f2</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00026</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1_finger</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1f2</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅫁</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1f2</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00026</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw">S1f2</td>
+<td class="signwriting col-signwriting-1">񅫁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00027.html
+++ b/docs/segments/seg00027.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1f3</title>
+  <title>Segment: Handshape S1f3</title>
   
 <style>
 @font-face {
@@ -12,128 +12,342 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1f3</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00027</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1_finger</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1f3</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅬱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1f3</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00027</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw">S1f3</td>
+<td class="signwriting col-signwriting-1">񅬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00028.html
+++ b/docs/segments/seg00028.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S106</title>
+  <title>Segment: Handshape S106</title>
   
 <style>
 @font-face {
@@ -12,358 +12,572 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S106</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00028</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1_finger</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers bent)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S106</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀉑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S106</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00028</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw">S106</td>
+<td class="signwriting col-signwriting-1">񀉑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
-<td>Hungarian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
+<td class="col-language">Hungarian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
-<td>Icelandic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
+<td class="col-language">Icelandic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00029.html
+++ b/docs/segments/seg00029.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S10a</title>
+  <title>Segment: Handshape S10a</title>
   
 <style>
 @font-face {
@@ -12,348 +12,562 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S10a</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00029</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1_finger</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers bent)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S10a</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀏑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S10a</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00029</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw">S10a</td>
+<td class="signwriting col-signwriting-1">񀏑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00070.html">NSL (NP) (SP_133)</a></td>
-<td>Nepalese Sign Language or Nepali Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00070.html">NSL (NP) (SP_133)</a></td>
+<td class="col-language">Nepalese Sign Language or Nepali Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00030.html
+++ b/docs/segments/seg00030.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S198</title>
+  <title>Segment: Handshape S198</title>
   
 <style>
 @font-face {
@@ -12,178 +12,392 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S198</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00030</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1_finger</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers bent)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S198</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񃤑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S198</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00030</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw">S198</td>
+<td class="signwriting col-signwriting-1">񃤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00031.html
+++ b/docs/segments/seg00031.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1e1</title>
+  <title>Segment: Handshape S1e1</title>
   
 <style>
 @font-face {
@@ -12,278 +12,492 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1e1</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00031</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1_finger</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers bent)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1e1</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅑱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting">񅑡</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1e1</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00031</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw">S1e1</td>
+<td class="signwriting col-signwriting-1">񅑱</td>
+<td class="signwriting col-signwriting-2">񅑡</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00032.html
+++ b/docs/segments/seg00032.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1e2</title>
+  <title>Segment: Handshape S1e2</title>
   
 <style>
 @font-face {
@@ -12,168 +12,382 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1e2</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00032</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1_finger</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers bent)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1e2</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅓁</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1e2</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00032</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw">S1e2</td>
+<td class="signwriting col-signwriting-1">񅓁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00033.html
+++ b/docs/segments/seg00033.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape Missing</title>
+  <title>Segment: Handshape Missing</title>
   
 <style>
 @font-face {
@@ -12,66 +12,277 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape Missing</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00033</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1_finger</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers bent)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>Missing</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <p>No inventories found for this segment.</p>
+    <section class="content-card">
+      <h1>Segment: Handshape Missing</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
+<thead><tr>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00033</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw">Missing</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <p>No inventories found for this segment.</p>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00034.html
+++ b/docs/segments/seg00034.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape Missing</title>
+  <title>Segment: Handshape Missing</title>
   
 <style>
 @font-face {
@@ -12,66 +12,277 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape Missing</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00034</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1_finger</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers bent)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>Missing</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <p>No inventories found for this segment.</p>
+    <section class="content-card">
+      <h1>Segment: Handshape Missing</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
+<thead><tr>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00034</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw">Missing</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <p>No inventories found for this segment.</p>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00035.html
+++ b/docs/segments/seg00035.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1ea</title>
+  <title>Segment: Handshape S1ea</title>
   
 <style>
 @font-face {
@@ -12,373 +12,587 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1ea</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00035</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1_finger</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers Hooked)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1ea</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅟑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting">񅟁</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1ea</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00035</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">1_finger</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw">S1ea</td>
+<td class="signwriting col-signwriting-1">񅟑</td>
+<td class="signwriting col-signwriting-2">񅟁</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
-<td>Hungarian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
+<td class="col-language">Hungarian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
-<td>Jordanian Sign Language or Levantine Arabic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
+<td class="col-language">Jordanian Sign Language or Levantine Arabic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
-<td>Romanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
+<td class="col-language">Romanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00036.html
+++ b/docs/segments/seg00036.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S115</title>
+  <title>Segment: Handshape S115</title>
   
 <style>
 @font-face {
@@ -12,453 +12,667 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S115</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00036</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S115</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀟱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S115</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00036</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S115</td>
+<td class="signwriting col-signwriting-1">񀟱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00016.html">ÖGS (SP_29)</a></td>
-<td>Austrian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00016.html">ÖGS (SP_29)</a></td>
+<td class="col-language">Austrian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00021.html">LSB (SP_45)</a></td>
-<td>Bolivian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00021.html">LSB (SP_45)</a></td>
+<td class="col-language">Bolivian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
-<td>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
+<td class="col-language">Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
-<td>Greek Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
+<td class="col-language">Greek Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
-<td>Hungarian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
+<td class="col-language">Hungarian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
-<td>Israeli Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
+<td class="col-language">Israeli Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
-<td>Jordanian Sign Language or Levantine Arabic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
+<td class="col-language">Jordanian Sign Language or Levantine Arabic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
-<td>Romanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
+<td class="col-language">Romanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00084.html">LESSA (SP_137)</a></td>
-<td>Salvadoran Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00084.html">LESSA (SP_137)</a></td>
+<td class="col-language">Salvadoran Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00037.html
+++ b/docs/segments/seg00037.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S12d</title>
+  <title>Segment: Handshape S12d</title>
   
 <style>
 @font-face {
@@ -12,328 +12,542 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S12d</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00037</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S12d</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񁃡</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting">񁃱</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S12d</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00037</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S12d</td>
+<td class="signwriting col-signwriting-1">񁃡</td>
+<td class="signwriting col-signwriting-2">񁃱</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00035.html">LSEC (SP_136)</a></td>
-<td>Ecuadorian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00035.html">LSEC (SP_136)</a></td>
+<td class="col-language">Ecuadorian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00036.html">EVK (SP_109)</a></td>
-<td>Estonian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00036.html">EVK (SP_109)</a></td>
+<td class="col-language">Estonian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00037.html">ESL (SP_84)</a></td>
-<td>Egypt Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00037.html">ESL (SP_84)</a></td>
+<td class="col-language">Egypt Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00046.html">Lensegua (SP_112)</a></td>
-<td>Guatemalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00046.html">Lensegua (SP_112)</a></td>
+<td class="col-language">Guatemalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00047.html">HKSL (SP_12)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00047.html">HKSL (SP_12)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00049.html">LSH (SP_113)</a></td>
-<td>Haitian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00049.html">LSH (SP_113)</a></td>
+<td class="col-language">Haitian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00060.html">LGK (SP_107)</a></td>
-<td>Lithuanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00060.html">LGK (SP_107)</a></td>
+<td class="col-language">Lithuanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00061.html">LSL (SP_108)</a></td>
-<td>Latvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00061.html">LSL (SP_108)</a></td>
+<td class="col-language">Latvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00083.html">SPJ (SP_89)</a></td>
-<td>Slovakian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00083.html">SPJ (SP_89)</a></td>
+<td class="col-language">Slovakian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00038.html
+++ b/docs/segments/seg00038.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1b5</title>
+  <title>Segment: Handshape S1b5</title>
   
 <style>
 @font-face {
@@ -12,103 +12,317 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1b5</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00038</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1b5</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񄏱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1b5</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00038</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S1b5</td>
+<td class="signwriting col-signwriting-1">񄏱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00039.html
+++ b/docs/segments/seg00039.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S119</title>
+  <title>Segment: Handshape S119</title>
   
 <style>
 @font-face {
@@ -12,303 +12,517 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S119</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00039</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S119</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀥱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S119</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00039</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw">S119</td>
+<td class="signwriting col-signwriting-1">񀥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
-<td>Icelandic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
+<td class="col-language">Icelandic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00040.html
+++ b/docs/segments/seg00040.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S132</title>
+  <title>Segment: Handshape S132</title>
   
 <style>
 @font-face {
@@ -12,153 +12,367 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S132</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00040</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S132</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񁋑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S132</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00040</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw">S132</td>
+<td class="signwriting col-signwriting-1">񁋑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00041.html
+++ b/docs/segments/seg00041.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S13e</title>
+  <title>Segment: Handshape S13e</title>
   
 <style>
 @font-face {
@@ -12,108 +12,322 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S13e</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00041</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S13e</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񁝑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S13e</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00041</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw">S13e</td>
+<td class="signwriting col-signwriting-1">񁝑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00042.html
+++ b/docs/segments/seg00042.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S110</title>
+  <title>Segment: Handshape S110</title>
   
 <style>
 @font-face {
@@ -12,328 +12,542 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S110</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00042</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers bent)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S110</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀘑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S110</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00042</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw">S110</td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
-<td>Israeli Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
+<td class="col-language">Israeli Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00043.html
+++ b/docs/segments/seg00043.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S118</title>
+  <title>Segment: Handshape S118</title>
   
 <style>
 @font-face {
@@ -12,323 +12,537 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S118</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00043</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers bent)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S118</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀤑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S118</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00043</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw">S118</td>
+<td class="signwriting col-signwriting-1">񀤑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
-<td>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
+<td class="col-language">Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
-<td>Hungarian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
+<td class="col-language">Hungarian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
-<td>Romanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
+<td class="col-language">Romanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00044.html
+++ b/docs/segments/seg00044.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S121</title>
+  <title>Segment: Handshape S121</title>
   
 <style>
 @font-face {
@@ -12,173 +12,387 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S121</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00044</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers bent)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S121</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀱱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S121</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00044</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw">S121</td>
+<td class="signwriting col-signwriting-1">񀱱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00045.html
+++ b/docs/segments/seg00045.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape None</title>
+  <title>Segment: Handshape None</title>
   
 <style>
 @font-face {
@@ -12,66 +12,277 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape None</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00045</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers Hooked)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>None</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <p>No inventories found for this segment.</p>
+    <section class="content-card">
+      <h1>Segment: Handshape None</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
+<thead><tr>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00045</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw">None</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <p>No inventories found for this segment.</p>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00046.html
+++ b/docs/segments/seg00046.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S116</title>
+  <title>Segment: Handshape S116</title>
   
 <style>
 @font-face {
@@ -12,113 +12,327 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S116</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00046</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>2finger_differshape</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S116</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀡑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S116</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00046</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw">S116</td>
+<td class="signwriting col-signwriting-1">񀡑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00047.html
+++ b/docs/segments/seg00047.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S11a</title>
+  <title>Segment: Handshape S11a</title>
   
 <style>
 @font-face {
@@ -12,383 +12,597 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S11a</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00047</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>2finger_differshape</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S11a</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀧑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting">񀧁</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S11a</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00047</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw">S11a</td>
+<td class="signwriting col-signwriting-1">񀧑</td>
+<td class="signwriting col-signwriting-2">񀧁</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00031.html">LESCO (SP_101)</a></td>
-<td>Costa Rican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00031.html">LESCO (SP_101)</a></td>
+<td class="col-language">Costa Rican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
-<td>Israeli Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
+<td class="col-language">Israeli Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00048.html
+++ b/docs/segments/seg00048.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S11d</title>
+  <title>Segment: Handshape S11d</title>
   
 <style>
 @font-face {
@@ -12,148 +12,362 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S11d</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00048</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>2finger_differshape</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S11d</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀫡</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S11d</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00048</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw">S11d</td>
+<td class="signwriting col-signwriting-1">񀫡</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
-<td>Greek Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
+<td class="col-language">Greek Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00049.html
+++ b/docs/segments/seg00049.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S126</title>
+  <title>Segment: Handshape S126</title>
   
 <style>
 @font-face {
@@ -12,93 +12,307 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S126</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00049</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>2finger_differshape</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S126</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀹑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S126</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00049</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw">S126</td>
+<td class="signwriting col-signwriting-1">񀹑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00050.html
+++ b/docs/segments/seg00050.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S10e</title>
+  <title>Segment: Handshape S10e</title>
   
 <style>
 @font-face {
@@ -12,443 +12,657 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S10e</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00050</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S10e</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀕁</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S10e</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00050</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S10e</td>
+<td class="signwriting col-signwriting-1">񀕁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00021.html">LSB (SP_45)</a></td>
-<td>Bolivian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00021.html">LSB (SP_45)</a></td>
+<td class="col-language">Bolivian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
-<td>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
+<td class="col-language">Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
-<td>Greek Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
+<td class="col-language">Greek Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
-<td>Hungarian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
+<td class="col-language">Hungarian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
-<td>Jordanian Sign Language or Levantine Arabic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
+<td class="col-language">Jordanian Sign Language or Levantine Arabic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00058.html">KSL, LAK (SP_79)</a></td>
-<td>Kenya-Somali Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00058.html">KSL, LAK (SP_79)</a></td>
+<td class="col-language">Kenya-Somali Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00066.html">NSL (NG) (SP_32)</a></td>
-<td>Nigerian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00066.html">NSL (NG) (SP_32)</a></td>
+<td class="col-language">Nigerian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
-<td>Romanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
+<td class="col-language">Romanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00051.html
+++ b/docs/segments/seg00051.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S11e</title>
+  <title>Segment: Handshape S11e</title>
   
 <style>
 @font-face {
@@ -12,408 +12,622 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S11e</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00051</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S11e</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀭁</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S11e</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00051</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S11e</td>
+<td class="signwriting col-signwriting-1">񀭁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
-<td>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
+<td class="col-language">Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
-<td>Greek Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
+<td class="col-language">Greek Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
-<td>Hungarian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
+<td class="col-language">Hungarian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
-<td>Israeli Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
+<td class="col-language">Israeli Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
-<td>Icelandic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
+<td class="col-language">Icelandic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00052.html
+++ b/docs/segments/seg00052.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S125</title>
+  <title>Segment: Handshape S125</title>
   
 <style>
 @font-face {
@@ -12,93 +12,307 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S125</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00052</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S125</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀷱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S125</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00052</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S125</td>
+<td class="signwriting col-signwriting-1">񀷱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00053.html
+++ b/docs/segments/seg00053.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S19c</title>
+  <title>Segment: Handshape S19c</title>
   
 <style>
 @font-face {
@@ -12,273 +12,487 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S19c</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00053</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S19c</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񃪑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S19c</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00053</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S19c</td>
+<td class="signwriting col-signwriting-1">񃪑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00054.html
+++ b/docs/segments/seg00054.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1a0</title>
+  <title>Segment: Handshape S1a0</title>
   
 <style>
 @font-face {
@@ -12,318 +12,532 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1a0</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00054</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1a0</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񃰑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1a0</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00054</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S1a0</td>
+<td class="signwriting col-signwriting-1">񃰑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
-<td>Greek Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
+<td class="col-language">Greek Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
-<td>Israeli Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
+<td class="col-language">Israeli Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00055.html
+++ b/docs/segments/seg00055.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1b0</title>
+  <title>Segment: Handshape S1b0</title>
   
 <style>
 @font-face {
@@ -12,123 +12,337 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1b0</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00055</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1b0</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񄈑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1b0</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00055</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S1b0</td>
+<td class="signwriting col-signwriting-1">񄈑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
-<td>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
+<td class="col-language">Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00056.html
+++ b/docs/segments/seg00056.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1b4</title>
+  <title>Segment: Handshape S1b4</title>
   
 <style>
 @font-face {
@@ -12,83 +12,297 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1b4</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00056</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1b4</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񄎑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1b4</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00056</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S1b4</td>
+<td class="signwriting col-signwriting-1">񄎑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00057.html
+++ b/docs/segments/seg00057.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1cb</title>
+  <title>Segment: Handshape S1cb</title>
   
 <style>
 @font-face {
@@ -12,113 +12,327 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1cb</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00057</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1cb</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񄰱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1cb</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00057</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S1cb</td>
+<td class="signwriting col-signwriting-1">񄰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00058.html
+++ b/docs/segments/seg00058.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S112</title>
+  <title>Segment: Handshape S112</title>
   
 <style>
 @font-face {
@@ -12,198 +12,412 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S112</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00058</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S112</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀛑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S112</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00058</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw">S112</td>
+<td class="signwriting col-signwriting-1">񀛑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00059.html
+++ b/docs/segments/seg00059.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S123</title>
+  <title>Segment: Handshape S123</title>
   
 <style>
 @font-face {
@@ -12,128 +12,342 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S123</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00059</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S123</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀴱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S123</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00059</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw">S123</td>
+<td class="signwriting col-signwriting-1">񀴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00060.html
+++ b/docs/segments/seg00060.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S110</title>
+  <title>Segment: Handshape S110</title>
   
 <style>
 @font-face {
@@ -12,328 +12,542 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S110</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00060</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers bent)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S110</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀘑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S110</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00060</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw">S110</td>
+<td class="signwriting col-signwriting-1">񀘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
-<td>Israeli Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
+<td class="col-language">Israeli Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00061.html
+++ b/docs/segments/seg00061.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S121</title>
+  <title>Segment: Handshape S121</title>
   
 <style>
 @font-face {
@@ -12,173 +12,387 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S121</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00061</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers bent)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S121</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀱱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S121</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00061</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw">S121</td>
+<td class="signwriting col-signwriting-1">񀱱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00062.html
+++ b/docs/segments/seg00062.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S122</title>
+  <title>Segment: Handshape S122</title>
   
 <style>
 @font-face {
@@ -12,183 +12,397 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S122</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00062</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers bent)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S122</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀳑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S122</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00062</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw">S122</td>
+<td class="signwriting col-signwriting-1">񀳑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00063.html
+++ b/docs/segments/seg00063.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S126</title>
+  <title>Segment: Handshape S126</title>
   
 <style>
 @font-face {
@@ -12,93 +12,307 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S126</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00063</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>2finger_differshape</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S126</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀹑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S126</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00063</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw">S126</td>
+<td class="signwriting col-signwriting-1">񀹑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00064.html
+++ b/docs/segments/seg00064.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S140</title>
+  <title>Segment: Handshape S140</title>
   
 <style>
 @font-face {
@@ -12,368 +12,582 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S140</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00064</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>2finger_differshape</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S140</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񁠑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S140</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00064</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw">S140</td>
+<td class="signwriting col-signwriting-1">񁠑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00013.html">AFSL (SP_106)</a></td>
-<td>Afghan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00013.html">AFSL (SP_106)</a></td>
+<td class="col-language">Afghan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
-<td>Israeli Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
+<td class="col-language">Israeli Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00065.html
+++ b/docs/segments/seg00065.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S142</title>
+  <title>Segment: Handshape S142</title>
   
 <style>
 @font-face {
@@ -12,183 +12,397 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S142</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00065</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>2finger_differshape</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S142</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񁣑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S142</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00065</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">2_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">2finger_differshape</td>
+<td class="col-fsw">S142</td>
+<td class="signwriting col-signwriting-1">񁣑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00058.html">KSL, LAK (SP_79)</a></td>
-<td>Kenya-Somali Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00058.html">KSL, LAK (SP_79)</a></td>
+<td class="col-language">Kenya-Somali Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00066.html
+++ b/docs/segments/seg00066.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S18e</title>
+  <title>Segment: Handshape S18e</title>
   
 <style>
 @font-face {
@@ -12,188 +12,402 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S18e</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00066</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>3_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>extended</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S18e</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񃕑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S18e</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00066</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw">S18e</td>
+<td class="signwriting col-signwriting-1">񃕑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
-<td>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
+<td class="col-language">Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00067.html
+++ b/docs/segments/seg00067.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape None</title>
+  <title>Segment: Handshape None</title>
   
 <style>
 @font-face {
@@ -12,66 +12,277 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape None</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00067</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>3_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>flattened</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>None</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <p>No inventories found for this segment.</p>
+    <section class="content-card">
+      <h1>Segment: Handshape None</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
+<thead><tr>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00067</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">flattened</td>
+<td class="col-fsw">None</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <p>No inventories found for this segment.</p>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00068.html
+++ b/docs/segments/seg00068.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape None</title>
+  <title>Segment: Handshape None</title>
   
 <style>
 @font-face {
@@ -12,66 +12,277 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape None</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00068</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>3_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>bent</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>None</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <p>No inventories found for this segment.</p>
+    <section class="content-card">
+      <h1>Segment: Handshape None</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
+<thead><tr>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00068</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">bent</td>
+<td class="col-fsw">None</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <p>No inventories found for this segment.</p>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00069.html
+++ b/docs/segments/seg00069.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape None</title>
+  <title>Segment: Handshape None</title>
   
 <style>
 @font-face {
@@ -12,66 +12,277 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape None</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00069</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>3_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>hooked</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>None</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <p>No inventories found for this segment.</p>
+    <section class="content-card">
+      <h1>Segment: Handshape None</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
+<thead><tr>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00069</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">hooked</td>
+<td class="col-fsw">None</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <p>No inventories found for this segment.</p>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00070.html
+++ b/docs/segments/seg00070.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape None</title>
+  <title>Segment: Handshape None</title>
   
 <style>
 @font-face {
@@ -12,66 +12,277 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape None</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00070</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>3_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>3finger_differshape</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>None</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <p>No inventories found for this segment.</p>
+    <section class="content-card">
+      <h1>Segment: Handshape None</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
+<thead><tr>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00070</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">3finger_differshape</td>
+<td class="col-fsw">None</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <p>No inventories found for this segment.</p>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00071.html
+++ b/docs/segments/seg00071.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S18f</title>
+  <title>Segment: Handshape S18f</title>
   
 <style>
 @font-face {
@@ -12,113 +12,327 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S18f</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00071</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>3_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>extended</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S18f</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񃖱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S18f</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00071</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw">S18f</td>
+<td class="signwriting col-signwriting-1">񃖱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00072.html
+++ b/docs/segments/seg00072.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1a4</title>
+  <title>Segment: Handshape S1a4</title>
   
 <style>
 @font-face {
@@ -12,148 +12,362 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1a4</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00072</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>3_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>extended</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1a4</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񃶁</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1a4</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00072</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw">S1a4</td>
+<td class="signwriting col-signwriting-1">񃶁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00073.html
+++ b/docs/segments/seg00073.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1ab</title>
+  <title>Segment: Handshape S1ab</title>
   
 <style>
 @font-face {
@@ -12,93 +12,307 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1ab</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00073</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>3_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>extended</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1ab</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񄀱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1ab</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00073</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw">S1ab</td>
+<td class="signwriting col-signwriting-1">񄀱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00074.html
+++ b/docs/segments/seg00074.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1c4</title>
+  <title>Segment: Handshape S1c4</title>
   
 <style>
 @font-face {
@@ -12,133 +12,347 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1c4</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00074</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>3_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>extended</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1c4</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񄦑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1c4</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00074</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">extended</td>
+<td class="col-fsw">S1c4</td>
+<td class="signwriting col-signwriting-1">񄦑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00075.html
+++ b/docs/segments/seg00075.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape None</title>
+  <title>Segment: Handshape None</title>
   
 <style>
 @font-face {
@@ -12,66 +12,277 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape None</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00075</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>3_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>flattened</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>None</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <p>No inventories found for this segment.</p>
+    <section class="content-card">
+      <h1>Segment: Handshape None</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
+<thead><tr>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00075</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">flattened</td>
+<td class="col-fsw">None</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <p>No inventories found for this segment.</p>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00076.html
+++ b/docs/segments/seg00076.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S190</title>
+  <title>Segment: Handshape S190</title>
   
 <style>
 @font-face {
@@ -12,98 +12,312 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S190</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00076</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>3_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>bent</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S190</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񃘑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S190</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00076</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">bent</td>
+<td class="col-fsw">S190</td>
+<td class="signwriting col-signwriting-1">񃘑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00077.html
+++ b/docs/segments/seg00077.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape None</title>
+  <title>Segment: Handshape None</title>
   
 <style>
 @font-face {
@@ -12,66 +12,277 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape None</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00077</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>3_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>hooked</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>None</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <p>No inventories found for this segment.</p>
+    <section class="content-card">
+      <h1>Segment: Handshape None</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
+<thead><tr>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00077</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">hooked</td>
+<td class="col-fsw">None</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <p>No inventories found for this segment.</p>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00078.html
+++ b/docs/segments/seg00078.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape None</title>
+  <title>Segment: Handshape None</title>
   
 <style>
 @font-face {
@@ -12,66 +12,277 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape None</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00078</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>3_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>3finger_differshape</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>None</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <p>No inventories found for this segment.</p>
+    <section class="content-card">
+      <h1>Segment: Handshape None</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
+<thead><tr>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00078</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">3_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">3finger_differshape</td>
+<td class="col-fsw">None</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <p>No inventories found for this segment.</p>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00079.html
+++ b/docs/segments/seg00079.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S147</title>
+  <title>Segment: Handshape S147</title>
   
 <style>
 @font-face {
@@ -12,393 +12,607 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S147</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00079</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S147</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񁪱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting">񁫁</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S147</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00079</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S147</td>
+<td class="signwriting col-signwriting-1">񁪱</td>
+<td class="signwriting col-signwriting-2">񁫁</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
-<td>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
+<td class="col-language">Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
-<td>Greek Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
+<td class="col-language">Greek Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
-<td>Israeli Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
+<td class="col-language">Israeli Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
-<td>Romanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
+<td class="col-language">Romanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00080.html
+++ b/docs/segments/seg00080.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S15a</title>
+  <title>Segment: Handshape S15a</title>
   
 <style>
 @font-face {
@@ -12,418 +12,632 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S15a</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00080</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S15a</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񂇁</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting">񂇑</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S15a</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00080</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S15a</td>
+<td class="signwriting col-signwriting-1">񂇁</td>
+<td class="signwriting col-signwriting-2">񂇑</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00013.html">AFSL (SP_106)</a></td>
-<td>Afghan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00013.html">AFSL (SP_106)</a></td>
+<td class="col-language">Afghan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00021.html">LSB (SP_45)</a></td>
-<td>Bolivian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00021.html">LSB (SP_45)</a></td>
+<td class="col-language">Bolivian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
-<td>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
+<td class="col-language">Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
-<td>Hungarian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
+<td class="col-language">Hungarian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
-<td>Icelandic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
+<td class="col-language">Icelandic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
-<td>Jordanian Sign Language or Levantine Arabic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
+<td class="col-language">Jordanian Sign Language or Levantine Arabic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00065.html">BIM (SP_66)</a></td>
-<td>Malaysian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00065.html">BIM (SP_66)</a></td>
+<td class="col-language">Malaysian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00066.html">NSL (NG) (SP_32)</a></td>
-<td>Nigerian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00066.html">NSL (NG) (SP_32)</a></td>
+<td class="col-language">Nigerian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00070.html">NSL (NP) (SP_133)</a></td>
-<td>Nepalese Sign Language or Nepali Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00070.html">NSL (NP) (SP_133)</a></td>
+<td class="col-language">Nepalese Sign Language or Nepali Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00074.html">PSL (SP_87)</a></td>
-<td>Pakistan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00074.html">PSL (SP_87)</a></td>
+<td class="col-language">Pakistan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00081.html
+++ b/docs/segments/seg00081.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S15d</title>
+  <title>Segment: Handshape S15d</title>
   
 <style>
 @font-face {
@@ -12,448 +12,662 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S15d</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00081</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S15d</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񂋱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting">񂋡</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S15d</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00081</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S15d</td>
+<td class="signwriting col-signwriting-1">񂋱</td>
+<td class="signwriting col-signwriting-2">񂋡</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00013.html">AFSL (SP_106)</a></td>
-<td>Afghan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00013.html">AFSL (SP_106)</a></td>
+<td class="col-language">Afghan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00016.html">ÖGS (SP_29)</a></td>
-<td>Austrian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00016.html">ÖGS (SP_29)</a></td>
+<td class="col-language">Austrian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00021.html">LSB (SP_45)</a></td>
-<td>Bolivian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00021.html">LSB (SP_45)</a></td>
+<td class="col-language">Bolivian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
-<td>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
+<td class="col-language">Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
-<td>Icelandic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
+<td class="col-language">Icelandic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00058.html">KSL, LAK (SP_79)</a></td>
-<td>Kenya-Somali Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00058.html">KSL, LAK (SP_79)</a></td>
+<td class="col-language">Kenya-Somali Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00065.html">BIM (SP_66)</a></td>
-<td>Malaysian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00065.html">BIM (SP_66)</a></td>
+<td class="col-language">Malaysian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00066.html">NSL (NG) (SP_32)</a></td>
-<td>Nigerian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00066.html">NSL (NG) (SP_32)</a></td>
+<td class="col-language">Nigerian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00070.html">NSL (NP) (SP_133)</a></td>
-<td>Nepalese Sign Language or Nepali Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00070.html">NSL (NP) (SP_133)</a></td>
+<td class="col-language">Nepalese Sign Language or Nepali Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00074.html">PSL (SP_87)</a></td>
-<td>Pakistan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00074.html">PSL (SP_87)</a></td>
+<td class="col-language">Pakistan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
-<td>Romanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
+<td class="col-language">Romanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00082.html
+++ b/docs/segments/seg00082.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S14b</title>
+  <title>Segment: Handshape S14b</title>
   
 <style>
 @font-face {
@@ -12,198 +12,412 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S14b</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00082</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S14b</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񁰱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S14b</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00082</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw">S14b</td>
+<td class="signwriting col-signwriting-1">񁰱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00083.html
+++ b/docs/segments/seg00083.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S180</title>
+  <title>Segment: Handshape S180</title>
   
 <style>
 @font-face {
@@ -12,308 +12,522 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S180</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00083</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S180</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񃀑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting">񃀁</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S180</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00083</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw">S180</td>
+<td class="signwriting col-signwriting-1">񃀑</td>
+<td class="signwriting col-signwriting-2">񃀁</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00084.html
+++ b/docs/segments/seg00084.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S182</title>
+  <title>Segment: Handshape S182</title>
   
 <style>
 @font-face {
@@ -12,328 +12,542 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S182</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00084</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S182</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񃃑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S182</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00084</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw">S182</td>
+<td class="signwriting col-signwriting-1">񃃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00013.html">AFSL (SP_106)</a></td>
-<td>Afghan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00013.html">AFSL (SP_106)</a></td>
+<td class="col-language">Afghan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
-<td>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
+<td class="col-language">Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
-<td>Icelandic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
+<td class="col-language">Icelandic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
-<td>Jordanian Sign Language or Levantine Arabic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
+<td class="col-language">Jordanian Sign Language or Levantine Arabic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00074.html">PSL (SP_87)</a></td>
-<td>Pakistan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00074.html">PSL (SP_87)</a></td>
+<td class="col-language">Pakistan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
-<td>Romanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
+<td class="col-language">Romanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00085.html
+++ b/docs/segments/seg00085.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S149</title>
+  <title>Segment: Handshape S149</title>
   
 <style>
 @font-face {
@@ -12,148 +12,362 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S149</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00085</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers bent)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S149</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񁭱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S149</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00085</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw">S149</td>
+<td class="signwriting col-signwriting-1">񁭱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00086.html
+++ b/docs/segments/seg00086.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S168</title>
+  <title>Segment: Handshape S168</title>
   
 <style>
 @font-face {
@@ -12,123 +12,337 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S168</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00086</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers bent)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S168</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񂜑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S168</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00086</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw">S168</td>
+<td class="signwriting col-signwriting-1">񂜑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00087.html
+++ b/docs/segments/seg00087.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S16e</title>
+  <title>Segment: Handshape S16e</title>
   
 <style>
 @font-face {
@@ -12,158 +12,372 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S16e</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00087</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers bent)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S16e</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񂥑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S16e</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00087</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw">S16e</td>
+<td class="signwriting col-signwriting-1">񂥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
-<td>Hungarian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
+<td class="col-language">Hungarian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00088.html
+++ b/docs/segments/seg00088.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S170</title>
+  <title>Segment: Handshape S170</title>
   
 <style>
 @font-face {
@@ -12,168 +12,382 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S170</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00088</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers bent)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S170</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񂨑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S170</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00088</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw">S170</td>
+<td class="signwriting col-signwriting-1">񂨑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00089.html
+++ b/docs/segments/seg00089.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S171</title>
+  <title>Segment: Handshape S171</title>
   
 <style>
 @font-face {
@@ -12,238 +12,452 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S171</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00089</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers bent)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S171</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񂩱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S171</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00089</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw">S171</td>
+<td class="signwriting col-signwriting-1">񂩱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
-<td>Israeli Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
+<td class="col-language">Israeli Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
-<td>Icelandic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
+<td class="col-language">Icelandic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00058.html">KSL, LAK (SP_79)</a></td>
-<td>Kenya-Somali Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00058.html">KSL, LAK (SP_79)</a></td>
+<td class="col-language">Kenya-Somali Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00090.html
+++ b/docs/segments/seg00090.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S202</title>
+  <title>Segment: Handshape S202</title>
   
 <style>
 @font-face {
@@ -12,93 +12,307 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S202</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00090</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers Hooked)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S202</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񆃑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S202</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00090</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw">S202</td>
+<td class="signwriting col-signwriting-1">񆃑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00091.html
+++ b/docs/segments/seg00091.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1d7</title>
+  <title>Segment: Handshape S1d7</title>
   
 <style>
 @font-face {
@@ -12,108 +12,322 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1d7</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00091</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4_nonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>4finger_differshape</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1d7</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅂱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1d7</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00091</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_nonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw">S1d7</td>
+<td class="signwriting col-signwriting-1">񅂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00092.html
+++ b/docs/segments/seg00092.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S144</title>
+  <title>Segment: Handshape S144</title>
   
 <style>
 @font-face {
@@ -12,388 +12,602 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S144</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00092</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S144</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񁦁</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting">񁦡</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S144</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00092</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S144</td>
+<td class="signwriting col-signwriting-1">񁦁</td>
+<td class="signwriting col-signwriting-2">񁦡</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
-<td>Icelandic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
+<td class="col-language">Icelandic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00093.html
+++ b/docs/segments/seg00093.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S14c</title>
+  <title>Segment: Handshape S14c</title>
   
 <style>
 @font-face {
@@ -12,493 +12,707 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S14c</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00093</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers extended)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S14c</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񁲁</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S14c</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00093</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers extended)</td>
+<td class="col-fsw">S14c</td>
+<td class="signwriting col-signwriting-1">񁲁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00013.html">AFSL (SP_106)</a></td>
-<td>Afghan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00013.html">AFSL (SP_106)</a></td>
+<td class="col-language">Afghan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00020.html">BZhE (SP_134)</a></td>
-<td>Bulgarian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00020.html">BZhE (SP_134)</a></td>
+<td class="col-language">Bulgarian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00035.html">LSEC (SP_136)</a></td>
-<td>Ecuadorian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00035.html">LSEC (SP_136)</a></td>
+<td class="col-language">Ecuadorian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00036.html">EVK (SP_109)</a></td>
-<td>Estonian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00036.html">EVK (SP_109)</a></td>
+<td class="col-language">Estonian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00037.html">ESL (SP_84)</a></td>
-<td>Egypt Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00037.html">ESL (SP_84)</a></td>
+<td class="col-language">Egypt Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
-<td>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
+<td class="col-language">Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00046.html">Lensegua (SP_112)</a></td>
-<td>Guatemalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00046.html">Lensegua (SP_112)</a></td>
+<td class="col-language">Guatemalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00047.html">HKSL (SP_12)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00047.html">HKSL (SP_12)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00049.html">LSH (SP_113)</a></td>
-<td>Haitian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00049.html">LSH (SP_113)</a></td>
+<td class="col-language">Haitian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
-<td>Hungarian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
+<td class="col-language">Hungarian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
-<td>Icelandic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
+<td class="col-language">Icelandic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00058.html">KSL, LAK (SP_79)</a></td>
-<td>Kenya-Somali Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00058.html">KSL, LAK (SP_79)</a></td>
+<td class="col-language">Kenya-Somali Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00060.html">LGK (SP_107)</a></td>
-<td>Lithuanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00060.html">LGK (SP_107)</a></td>
+<td class="col-language">Lithuanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00061.html">LSL (SP_108)</a></td>
-<td>Latvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00061.html">LSL (SP_108)</a></td>
+<td class="col-language">Latvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00066.html">NSL (NG) (SP_32)</a></td>
-<td>Nigerian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00066.html">NSL (NG) (SP_32)</a></td>
+<td class="col-language">Nigerian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00074.html">PSL (SP_87)</a></td>
-<td>Pakistan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00074.html">PSL (SP_87)</a></td>
+<td class="col-language">Pakistan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
-<td>Romanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
+<td class="col-language">Romanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00083.html">SPJ (SP_89)</a></td>
-<td>Slovakian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00083.html">SPJ (SP_89)</a></td>
+<td class="col-language">Slovakian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00094.html
+++ b/docs/segments/seg00094.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S146</title>
+  <title>Segment: Handshape S146</title>
   
 <style>
 @font-face {
@@ -12,143 +12,357 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S146</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00094</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S146</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񁩑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S146</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00094</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw">S146</td>
+<td class="signwriting col-signwriting-1">񁩑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00095.html
+++ b/docs/segments/seg00095.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S158</title>
+  <title>Segment: Handshape S158</title>
   
 <style>
 @font-face {
@@ -12,198 +12,412 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S158</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00095</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S158</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񂄑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S158</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00095</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw">S158</td>
+<td class="signwriting col-signwriting-1">񂄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00096.html
+++ b/docs/segments/seg00096.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S159</title>
+  <title>Segment: Handshape S159</title>
   
 <style>
 @font-face {
@@ -12,113 +12,327 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S159</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00096</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S159</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񂅱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S159</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00096</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers flattened)</td>
+<td class="col-fsw">S159</td>
+<td class="signwriting col-signwriting-1">񂅱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00097.html
+++ b/docs/segments/seg00097.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S145</title>
+  <title>Segment: Handshape S145</title>
   
 <style>
 @font-face {
@@ -12,213 +12,427 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S145</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00097</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers bent)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S145</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񁧱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S145</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00097</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw">S145</td>
+<td class="signwriting col-signwriting-1">񁧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00098.html
+++ b/docs/segments/seg00098.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S14e</title>
+  <title>Segment: Handshape S14e</title>
   
 <style>
 @font-face {
@@ -12,283 +12,497 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S14e</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00098</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers bent)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S14e</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񁵑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S14e</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00098</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw">S14e</td>
+<td class="signwriting col-signwriting-1">񁵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
-<td>Hungarian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
+<td class="col-language">Hungarian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
-<td>Jordanian Sign Language or Levantine Arabic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
+<td class="col-language">Jordanian Sign Language or Levantine Arabic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
-<td>Romanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
+<td class="col-language">Romanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00099.html
+++ b/docs/segments/seg00099.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S150</title>
+  <title>Segment: Handshape S150</title>
   
 <style>
 @font-face {
@@ -12,343 +12,557 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S150</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00099</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers bent)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S150</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񁸑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S150</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00099</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers bent)</td>
+<td class="col-fsw">S150</td>
+<td class="signwriting col-signwriting-1">񁸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
-<td>Hungarian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
+<td class="col-language">Hungarian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
-<td>Jordanian Sign Language or Levantine Arabic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
+<td class="col-language">Jordanian Sign Language or Levantine Arabic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00058.html">KSL, LAK (SP_79)</a></td>
-<td>Kenya-Somali Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00058.html">KSL, LAK (SP_79)</a></td>
+<td class="col-language">Kenya-Somali Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00100.html
+++ b/docs/segments/seg00100.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape None</title>
+  <title>Segment: Handshape None</title>
   
 <style>
 @font-face {
@@ -12,66 +12,277 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape None</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00100</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(Selected Fingers Hooked)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>None</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <p>No inventories found for this segment.</p>
+    <section class="content-card">
+      <h1>Segment: Handshape None</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
+<thead><tr>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00100</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">(Selected Fingers Hooked)</td>
+<td class="col-fsw">None</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <p>No inventories found for this segment.</p>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00101.html
+++ b/docs/segments/seg00101.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S157</title>
+  <title>Segment: Handshape S157</title>
   
 <style>
 @font-face {
@@ -12,293 +12,507 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S157</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00101</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>4finger_differshape</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S157</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񂂱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S157</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00101</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw">S157</td>
+<td class="signwriting col-signwriting-1">񂂱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00013.html">AFSL (SP_106)</a></td>
-<td>Afghan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00013.html">AFSL (SP_106)</a></td>
+<td class="col-language">Afghan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
-<td>Icelandic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
+<td class="col-language">Icelandic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00102.html
+++ b/docs/segments/seg00102.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1a7</title>
+  <title>Segment: Handshape S1a7</title>
   
 <style>
 @font-face {
@@ -12,133 +12,347 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1a7</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00102</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>4finger_differshape</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1a7</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񃺱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1a7</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00102</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw">S1a7</td>
+<td class="signwriting col-signwriting-1">񃺱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00103.html
+++ b/docs/segments/seg00103.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1c5</title>
+  <title>Segment: Handshape S1c5</title>
   
 <style>
 @font-face {
@@ -12,323 +12,537 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1c5</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00103</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Selected fingers</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4_spread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>4finger_differshape</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1c5</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񄧱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1c5</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00103</td>
+<td class="col-hamnosys-1-initial-configuration">Selected fingers</td>
+<td class="col-hamnosys-2-basic-handshape">4_spread</td>
+<td class="col-hamnosys-3-handshape-modifications">4finger_differshape</td>
+<td class="col-fsw">S1c5</td>
+<td class="signwriting col-signwriting-1">񄧱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
-<td>Romanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
+<td class="col-language">Romanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00104.html
+++ b/docs/segments/seg00104.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S199</title>
+  <title>Segment: Handshape S199</title>
   
 <style>
 @font-face {
@@ -12,93 +12,307 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S199</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00104</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersFist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers rounded)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S199</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񃥱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S199</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00104</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw">S199</td>
+<td class="signwriting col-signwriting-1">񃥱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00105.html
+++ b/docs/segments/seg00105.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1e5</title>
+  <title>Segment: Handshape S1e5</title>
   
 <style>
 @font-face {
@@ -12,153 +12,367 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1e5</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00105</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersFist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers rounded)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1e5</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅗱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1e5</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00105</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw">S1e5</td>
+<td class="signwriting col-signwriting-1">񅗱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
-<td>Greek Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
+<td class="col-language">Greek Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00106.html
+++ b/docs/segments/seg00106.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1e7</title>
+  <title>Segment: Handshape S1e7</title>
   
 <style>
 @font-face {
@@ -12,143 +12,357 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1e7</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00106</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersFist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers rounded)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1e7</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅚱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1e7</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00106</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw">S1e7</td>
+<td class="signwriting col-signwriting-1">񅚱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00107.html
+++ b/docs/segments/seg00107.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1eb</title>
+  <title>Segment: Handshape S1eb</title>
   
 <style>
 @font-face {
@@ -12,333 +12,547 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1eb</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00107</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersFist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers rounded)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1eb</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅠱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1eb</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00107</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw">S1eb</td>
+<td class="signwriting col-signwriting-1">񅠱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
-<td>Icelandic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
+<td class="col-language">Icelandic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00074.html">PSL (SP_87)</a></td>
-<td>Pakistan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00074.html">PSL (SP_87)</a></td>
+<td class="col-language">Pakistan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00108.html
+++ b/docs/segments/seg00108.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1ed</title>
+  <title>Segment: Handshape S1ed</title>
   
 <style>
 @font-face {
@@ -12,323 +12,537 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1ed</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00108</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersFist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers rounded)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1ed</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅣡</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting">񅢑</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1ed</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00108</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw">S1ed</td>
+<td class="signwriting col-signwriting-1">񅣡</td>
+<td class="signwriting col-signwriting-2">񅢑</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00070.html">NSL (NP) (SP_133)</a></td>
-<td>Nepalese Sign Language or Nepali Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00070.html">NSL (NP) (SP_133)</a></td>
+<td class="col-language">Nepalese Sign Language or Nepali Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00109.html
+++ b/docs/segments/seg00109.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S19f</title>
+  <title>Segment: Handshape S19f</title>
   
 <style>
 @font-face {
@@ -12,103 +12,317 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S19f</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00109</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersFist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>FlattenedandInFistfingerUp</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S19f</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񃮱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S19f</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00109</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw">S19f</td>
+<td class="signwriting col-signwriting-1">񃮱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00110.html
+++ b/docs/segments/seg00110.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1e4</title>
+  <title>Segment: Handshape S1e4</title>
   
 <style>
 @font-face {
@@ -12,178 +12,392 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1e4</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00110</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersFist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers straight)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1e4</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅖑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1e4</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00110</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw">S1e4</td>
+<td class="signwriting col-signwriting-1">񅖑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00111.html
+++ b/docs/segments/seg00111.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1ee</title>
+  <title>Segment: Handshape S1ee</title>
   
 <style>
 @font-face {
@@ -12,238 +12,452 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1ee</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00111</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersFist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1ee</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅥑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1ee</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00111</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw">S1ee</td>
+<td class="signwriting col-signwriting-1">񅥑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00112.html
+++ b/docs/segments/seg00112.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1f0</title>
+  <title>Segment: Handshape S1f0</title>
   
 <style>
 @font-face {
@@ -12,328 +12,542 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1f0</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00112</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersFist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1f0</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅨑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting">񅨁</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1f0</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00112</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw">S1f0</td>
+<td class="signwriting col-signwriting-1">񅨑</td>
+<td class="signwriting col-signwriting-2">񅨁</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00113.html
+++ b/docs/segments/seg00113.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1f4</title>
+  <title>Segment: Handshape S1f4</title>
   
 <style>
 @font-face {
@@ -12,318 +12,532 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1f4</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00113</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersFist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1f4</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅮁</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting">񅮑</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1f4</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00113</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw">S1f4</td>
+<td class="signwriting col-signwriting-1">񅮁</td>
+<td class="signwriting col-signwriting-2">񅮑</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00027.html">LIS-SI (SP_50)</a></td>
-<td>Swiss-Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00027.html">LIS-SI (SP_50)</a></td>
+<td class="col-language">Swiss-Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00058.html">KSL, LAK (SP_79)</a></td>
-<td>Kenya-Somali Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00058.html">KSL, LAK (SP_79)</a></td>
+<td class="col-language">Kenya-Somali Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00114.html
+++ b/docs/segments/seg00114.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S129</title>
+  <title>Segment: Handshape S129</title>
   
 <style>
 @font-face {
@@ -12,238 +12,452 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S129</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00114</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2finNonspread_othersFist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers rounded)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S129</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀽱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S129</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00114</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw">S129</td>
+<td class="signwriting col-signwriting-1">񀽱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
-<td>Jordanian Sign Language or Levantine Arabic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
+<td class="col-language">Jordanian Sign Language or Levantine Arabic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00115.html
+++ b/docs/segments/seg00115.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S13d</title>
+  <title>Segment: Handshape S13d</title>
   
 <style>
 @font-face {
@@ -12,243 +12,457 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S13d</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00115</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2finNonspread_othersFist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S13d</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񁛡</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting">񁛱</td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S13d</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00115</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw">S13d</td>
+<td class="signwriting col-signwriting-1">񁛡</td>
+<td class="signwriting col-signwriting-2">񁛱</td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
-<td>Romanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
+<td class="col-language">Romanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00116.html
+++ b/docs/segments/seg00116.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S13f</title>
+  <title>Segment: Handshape S13f</title>
   
 <style>
 @font-face {
@@ -12,313 +12,527 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S13f</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00116</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2finNonspread_othersFist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S13f</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񁞱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S13f</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00116</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw">S13f</td>
+<td class="signwriting col-signwriting-1">񁞱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
-<td>Romanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
+<td class="col-language">Romanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00117.html
+++ b/docs/segments/seg00117.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape None</title>
+  <title>Segment: Handshape None</title>
   
 <style>
 @font-face {
@@ -12,66 +12,277 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape None</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00117</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2finNonspread_othersFist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers straight)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>None</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <p>No inventories found for this segment.</p>
+    <section class="content-card">
+      <h1>Segment: Handshape None</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
+<thead><tr>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00117</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw">None</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <p>No inventories found for this segment.</p>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00118.html
+++ b/docs/segments/seg00118.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1a3</title>
+  <title>Segment: Handshape S1a3</title>
   
 <style>
 @font-face {
@@ -12,203 +12,417 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1a3</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00118</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2finNonspread_othersFist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>FlattenedandInFistfingerUp</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1a3</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񃴱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1a3</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00118</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw">S1a3</td>
+<td class="signwriting col-signwriting-1">񃴱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00119.html
+++ b/docs/segments/seg00119.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1b2</title>
+  <title>Segment: Handshape S1b2</title>
   
 <style>
 @font-face {
@@ -12,98 +12,312 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1b2</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00119</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2finNonspread_othersFist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>FlattenedandInFistfingerUp</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1b2</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񄋑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1b2</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00119</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw">S1b2</td>
+<td class="signwriting col-signwriting-1">񄋑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00120.html
+++ b/docs/segments/seg00120.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1b3</title>
+  <title>Segment: Handshape S1b3</title>
   
 <style>
 @font-face {
@@ -12,118 +12,332 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1b3</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00120</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2finNonspread_othersFist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>FlattenedandInFistfingerUp</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1b3</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񄌱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1b3</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00120</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finNonspread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw">S1b3</td>
+<td class="signwriting col-signwriting-1">񄌱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00121.html
+++ b/docs/segments/seg00121.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S128</title>
+  <title>Segment: Handshape S128</title>
   
 <style>
 @font-face {
@@ -12,233 +12,447 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S128</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00121</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2finSpread_othersFist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers rounded)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S128</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀼑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S128</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00121</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw">S128</td>
+<td class="signwriting col-signwriting-1">񀼑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00122.html
+++ b/docs/segments/seg00122.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S12a</title>
+  <title>Segment: Handshape S12a</title>
   
 <style>
 @font-face {
@@ -12,123 +12,337 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S12a</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00122</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2finSpread_othersFist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers rounded)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S12a</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀿑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S12a</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00122</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw">S12a</td>
+<td class="signwriting col-signwriting-1">񀿑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00123.html
+++ b/docs/segments/seg00123.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S12b</title>
+  <title>Segment: Handshape S12b</title>
   
 <style>
 @font-face {
@@ -12,168 +12,382 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S12b</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00123</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2finSpread_othersFist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S12b</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񁀱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S12b</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00123</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw">S12b</td>
+<td class="signwriting col-signwriting-1">񁀱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00124.html
+++ b/docs/segments/seg00124.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S127</title>
+  <title>Segment: Handshape S127</title>
   
 <style>
 @font-face {
@@ -12,133 +12,347 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S127</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00124</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2finSpread_othersFist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers straight)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S127</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀺱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S127</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00124</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw">S127</td>
+<td class="signwriting col-signwriting-1">񀺱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00125.html
+++ b/docs/segments/seg00125.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape None</title>
+  <title>Segment: Handshape None</title>
   
 <style>
 @font-face {
@@ -12,66 +12,277 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape None</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00125</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>2finSpread_othersFist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>FlattenedandInFistfingerUp</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>None</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <p>No inventories found for this segment.</p>
+    <section class="content-card">
+      <h1>Segment: Handshape None</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
+<thead><tr>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00125</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">2finSpread_othersFist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw">None</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <p>No inventories found for this segment.</p>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00126.html
+++ b/docs/segments/seg00126.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S16d</title>
+  <title>Segment: Handshape S16d</title>
   
 <style>
 @font-face {
@@ -12,403 +12,617 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S16d</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00126</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4finNonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers rounded)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S16d</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񂣱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S16d</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00126</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw">S16d</td>
+<td class="signwriting col-signwriting-1">񂣱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00013.html">AFSL (SP_106)</a></td>
-<td>Afghan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00013.html">AFSL (SP_106)</a></td>
+<td class="col-language">Afghan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00031.html">LESCO (SP_101)</a></td>
-<td>Costa Rican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00031.html">LESCO (SP_101)</a></td>
+<td class="col-language">Costa Rican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
-<td>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
+<td class="col-language">Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
-<td>Israeli Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
+<td class="col-language">Israeli Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
-<td>Jordanian Sign Language or Levantine Arabic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
+<td class="col-language">Jordanian Sign Language or Levantine Arabic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00127.html
+++ b/docs/segments/seg00127.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S173</title>
+  <title>Segment: Handshape S173</title>
   
 <style>
 @font-face {
@@ -12,173 +12,387 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S173</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00127</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4finNonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers rounded)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S173</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񂬱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S173</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00127</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw">S173</td>
+<td class="signwriting col-signwriting-1">񂬱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00128.html
+++ b/docs/segments/seg00128.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S176</title>
+  <title>Segment: Handshape S176</title>
   
 <style>
 @font-face {
@@ -12,418 +12,632 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S176</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00128</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4finNonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers rounded)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S176</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񂱑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S176</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00128</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw">S176</td>
+<td class="signwriting col-signwriting-1">񂱑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
-<td>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
+<td class="col-language">Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
-<td>Hungarian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
+<td class="col-language">Hungarian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
-<td>Israeli Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
+<td class="col-language">Israeli Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00066.html">NSL (NG) (SP_32)</a></td>
-<td>Nigerian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00066.html">NSL (NG) (SP_32)</a></td>
+<td class="col-language">Nigerian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00129.html
+++ b/docs/segments/seg00129.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S177</title>
+  <title>Segment: Handshape S177</title>
   
 <style>
 @font-face {
@@ -12,338 +12,552 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S177</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00129</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4finNonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers rounded)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S177</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񂲱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S177</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00129</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw">S177</td>
+<td class="signwriting col-signwriting-1">񂲱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00035.html">LSEC (SP_136)</a></td>
-<td>Ecuadorian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00035.html">LSEC (SP_136)</a></td>
+<td class="col-language">Ecuadorian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00036.html">EVK (SP_109)</a></td>
-<td>Estonian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00036.html">EVK (SP_109)</a></td>
+<td class="col-language">Estonian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00037.html">ESL (SP_84)</a></td>
-<td>Egypt Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00037.html">ESL (SP_84)</a></td>
+<td class="col-language">Egypt Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
-<td>Greek Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
+<td class="col-language">Greek Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00046.html">Lensegua (SP_112)</a></td>
-<td>Guatemalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00046.html">Lensegua (SP_112)</a></td>
+<td class="col-language">Guatemalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00047.html">HKSL (SP_12)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00047.html">HKSL (SP_12)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00049.html">LSH (SP_113)</a></td>
-<td>Haitian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00049.html">LSH (SP_113)</a></td>
+<td class="col-language">Haitian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
-<td>Icelandic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00054.html">ÍTM (SP_131)</a></td>
+<td class="col-language">Icelandic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
-<td>Jordanian Sign Language or Levantine Arabic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
+<td class="col-language">Jordanian Sign Language or Levantine Arabic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00060.html">LGK (SP_107)</a></td>
-<td>Lithuanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00060.html">LGK (SP_107)</a></td>
+<td class="col-language">Lithuanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00061.html">LSL (SP_108)</a></td>
-<td>Latvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00061.html">LSL (SP_108)</a></td>
+<td class="col-language">Latvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00074.html">PSL (SP_87)</a></td>
-<td>Pakistan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00074.html">PSL (SP_87)</a></td>
+<td class="col-language">Pakistan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00083.html">SPJ (SP_89)</a></td>
-<td>Slovakian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00083.html">SPJ (SP_89)</a></td>
+<td class="col-language">Slovakian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00130.html
+++ b/docs/segments/seg00130.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S17c</title>
+  <title>Segment: Handshape S17c</title>
   
 <style>
 @font-face {
@@ -12,223 +12,437 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S17c</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00130</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4finNonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S17c</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񂺑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S17c</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00130</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw">S17c</td>
+<td class="signwriting col-signwriting-1">񂺑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
-<td>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
+<td class="col-language">Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00131.html
+++ b/docs/segments/seg00131.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S17d</title>
+  <title>Segment: Handshape S17d</title>
   
 <style>
 @font-face {
@@ -12,308 +12,522 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S17d</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00131</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4finNonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S17d</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񂻱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S17d</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00131</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw">S17d</td>
+<td class="signwriting col-signwriting-1">񂻱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00020.html">BZhE (SP_134)</a></td>
-<td>Bulgarian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00020.html">BZhE (SP_134)</a></td>
+<td class="col-language">Bulgarian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00132.html
+++ b/docs/segments/seg00132.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S185</title>
+  <title>Segment: Handshape S185</title>
   
 <style>
 @font-face {
@@ -12,403 +12,617 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S185</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00132</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4finNonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S185</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񃇱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S185</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00132</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw">S185</td>
+<td class="signwriting col-signwriting-1">񃇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00013.html">AFSL (SP_106)</a></td>
-<td>Afghan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00013.html">AFSL (SP_106)</a></td>
+<td class="col-language">Afghan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00020.html">BZhE (SP_134)</a></td>
-<td>Bulgarian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00020.html">BZhE (SP_134)</a></td>
+<td class="col-language">Bulgarian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
-<td>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
+<td class="col-language">Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
-<td>Israeli Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
+<td class="col-language">Israeli Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
-<td>Romanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
+<td class="col-language">Romanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00133.html
+++ b/docs/segments/seg00133.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S160</title>
+  <title>Segment: Handshape S160</title>
   
 <style>
 @font-face {
@@ -12,248 +12,462 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S160</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00133</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4finNonspread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers straight)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S160</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񂐑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S160</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00133</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finNonspread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw">S160</td>
+<td class="signwriting col-signwriting-1">񂐑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00134.html
+++ b/docs/segments/seg00134.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S153</title>
+  <title>Segment: Handshape S153</title>
   
 <style>
 @font-face {
@@ -12,328 +12,542 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S153</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00134</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4finSpread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers rounded)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S153</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񁼱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S153</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00134</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw">S153</td>
+<td class="signwriting col-signwriting-1">񁼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00135.html
+++ b/docs/segments/seg00135.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S154</title>
+  <title>Segment: Handshape S154</title>
   
 <style>
 @font-face {
@@ -12,278 +12,492 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S154</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00135</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4finSpread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers rounded)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S154</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񁾑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S154</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00135</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw">S154</td>
+<td class="signwriting col-signwriting-1">񁾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00136.html
+++ b/docs/segments/seg00136.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S155</title>
+  <title>Segment: Handshape S155</title>
   
 <style>
 @font-face {
@@ -12,243 +12,457 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S155</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00136</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4finSpread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers rounded)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S155</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񁿱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S155</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00136</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers rounded)</td>
+<td class="col-fsw">S155</td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00137.html
+++ b/docs/segments/seg00137.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S155</title>
+  <title>Segment: Handshape S155</title>
   
 <style>
 @font-face {
@@ -12,243 +12,457 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S155</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00137</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4finSpread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S155</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񁿱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S155</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00137</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers flattened)</td>
+<td class="col-fsw">S155</td>
+<td class="signwriting col-signwriting-1">񁿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00138.html
+++ b/docs/segments/seg00138.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape None</title>
+  <title>Segment: Handshape None</title>
   
 <style>
 @font-face {
@@ -12,66 +12,277 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape None</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00138</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>4finSpread</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(fingers straight)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>None</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <p>No inventories found for this segment.</p>
+    <section class="content-card">
+      <h1>Segment: Handshape None</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
+<thead><tr>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00138</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">4finSpread</td>
+<td class="col-hamnosys-3-handshape-modifications">(fingers straight)</td>
+<td class="col-fsw">None</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <p>No inventories found for this segment.</p>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00139.html
+++ b/docs/segments/seg00139.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S187</title>
+  <title>Segment: Handshape S187</title>
   
 <style>
 @font-face {
@@ -12,298 +12,512 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S187</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00139</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersNonfist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(thumb rounded,others spread)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S187</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񃊱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S187</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00139</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw">S187</td>
+<td class="signwriting col-signwriting-1">񃊱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00140.html
+++ b/docs/segments/seg00140.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S18b</title>
+  <title>Segment: Handshape S18b</title>
   
 <style>
 @font-face {
@@ -12,193 +12,407 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S18b</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00140</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersNonfist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(thumb rounded,others spread)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S18b</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񃐱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S18b</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00140</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw">S18b</td>
+<td class="signwriting col-signwriting-1">񃐱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00141.html
+++ b/docs/segments/seg00141.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1a4</title>
+  <title>Segment: Handshape S1a4</title>
   
 <style>
 @font-face {
@@ -12,148 +12,362 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1a4</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00141</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersNonfist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(thumb rounded,others spread)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1a4</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񃶁</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1a4</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00141</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw">S1a4</td>
+<td class="signwriting col-signwriting-1">񃶁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00142.html
+++ b/docs/segments/seg00142.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1a5</title>
+  <title>Segment: Handshape S1a5</title>
   
 <style>
 @font-face {
@@ -12,163 +12,377 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1a5</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00142</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersNonfist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(thumb rounded,others spread)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1a5</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񃷱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1a5</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00142</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw">S1a5</td>
+<td class="signwriting col-signwriting-1">񃷱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00143.html
+++ b/docs/segments/seg00143.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1ba</title>
+  <title>Segment: Handshape S1ba</title>
   
 <style>
 @font-face {
@@ -12,133 +12,347 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1ba</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00143</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersNonfist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(thumb rounded,others spread)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1ba</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񄗁</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1ba</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00143</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw">S1ba</td>
+<td class="signwriting col-signwriting-1">񄗁</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00144.html
+++ b/docs/segments/seg00144.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1bb</title>
+  <title>Segment: Handshape S1bb</title>
   
 <style>
 @font-face {
@@ -12,293 +12,507 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1bb</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00144</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersNonfist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(thumb rounded,others spread)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1bb</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񄘱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1bb</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00144</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw">S1bb</td>
+<td class="signwriting col-signwriting-1">񄘱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00145.html
+++ b/docs/segments/seg00145.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1ce</title>
+  <title>Segment: Handshape S1ce</title>
   
 <style>
 @font-face {
@@ -12,418 +12,632 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1ce</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00145</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersNonfist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(thumb rounded,others spread)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1ce</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񄵑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1ce</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00145</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw">S1ce</td>
+<td class="signwriting col-signwriting-1">񄵑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00016.html">ÖGS (SP_29)</a></td>
-<td>Austrian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00016.html">ÖGS (SP_29)</a></td>
+<td class="col-language">Austrian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
-<td>Hungarian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
+<td class="col-language">Hungarian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00066.html">NSL (NG) (SP_32)</a></td>
-<td>Nigerian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00066.html">NSL (NG) (SP_32)</a></td>
+<td class="col-language">Nigerian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
-<td>Romanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
+<td class="col-language">Romanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00146.html
+++ b/docs/segments/seg00146.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1d0</title>
+  <title>Segment: Handshape S1d0</title>
   
 <style>
 @font-face {
@@ -12,248 +12,462 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1d0</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00146</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersNonfist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(thumb rounded,others spread)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1d0</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񄸑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1d0</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00146</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw">S1d0</td>
+<td class="signwriting col-signwriting-1">񄸑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
-<td>German Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00003.html">DGS (LQ_3)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00147.html
+++ b/docs/segments/seg00147.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1d5</title>
+  <title>Segment: Handshape S1d5</title>
   
 <style>
 @font-face {
@@ -12,153 +12,367 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1d5</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00147</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersNonfist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(thumb rounded,others spread)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1d5</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񄿱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1d5</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00147</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw">S1d5</td>
+<td class="signwriting col-signwriting-1">񄿱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00148.html
+++ b/docs/segments/seg00148.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1d6</title>
+  <title>Segment: Handshape S1d6</title>
   
 <style>
 @font-face {
@@ -12,108 +12,322 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1d6</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00148</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersNonfist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(thumb rounded,others spread)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1d6</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅁑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1d6</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00148</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw">S1d6</td>
+<td class="signwriting col-signwriting-1">񅁑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00149.html
+++ b/docs/segments/seg00149.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape Missing</title>
+  <title>Segment: Handshape Missing</title>
   
 <style>
 @font-face {
@@ -12,66 +12,277 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape Missing</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00149</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersNonfist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(thumb rounded,others spread)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>Missing</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <p>No inventories found for this segment.</p>
+    <section class="content-card">
+      <h1>Segment: Handshape Missing</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
+<thead><tr>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00149</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others spread)</td>
+<td class="col-fsw">Missing</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <p>No inventories found for this segment.</p>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00150.html
+++ b/docs/segments/seg00150.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S18c</title>
+  <title>Segment: Handshape S18c</title>
   
 <style>
 @font-face {
@@ -12,303 +12,517 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S18c</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00150</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersNonfist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(thumb rounded,others nonspread)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S18c</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񃒑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S18c</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00150</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw">S18c</td>
+<td class="signwriting col-signwriting-1">񃒑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
-<td>Greek Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
+<td class="col-language">Greek Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00151.html
+++ b/docs/segments/seg00151.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S18d</title>
+  <title>Segment: Handshape S18d</title>
   
 <style>
 @font-face {
@@ -12,293 +12,507 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S18d</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00151</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersNonfist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(thumb rounded,others nonspread)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S18d</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񃓱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S18d</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00151</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw">S18d</td>
+<td class="signwriting col-signwriting-1">񃓱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00152.html
+++ b/docs/segments/seg00152.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1da</title>
+  <title>Segment: Handshape S1da</title>
   
 <style>
 @font-face {
@@ -12,233 +12,447 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1da</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00152</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersNonfist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(thumb rounded,others nonspread)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1da</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅇑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1da</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00152</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb rounded,others nonspread)</td>
+<td class="col-fsw">S1da</td>
+<td class="signwriting col-signwriting-1">񅇑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
-<td>Hungarian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
+<td class="col-language">Hungarian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00153.html
+++ b/docs/segments/seg00153.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1c1</title>
+  <title>Segment: Handshape S1c1</title>
   
 <style>
 @font-face {
@@ -12,188 +12,402 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1c1</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00153</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersNonfist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(thumb flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1c1</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񄡱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1c1</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00153</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw">S1c1</td>
+<td class="signwriting col-signwriting-1">񄡱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
-<td>Korean Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00010.html">KSL (LQ_10)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00154.html
+++ b/docs/segments/seg00154.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1c3</title>
+  <title>Segment: Handshape S1c3</title>
   
 <style>
 @font-face {
@@ -12,233 +12,447 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1c3</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00154</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersNonfist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(thumb flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1c3</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񄤱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1c3</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00154</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw">S1c3</td>
+<td class="signwriting col-signwriting-1">񄤱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
-<td>Chinese Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00002.html">CSL, ZGS (LQ_2)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
-<td>Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00004.html">HKSL (LQ_4)</a></td>
+<td class="col-language">Hong Kong Sign Language or Hong Kong-Macau Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00155.html
+++ b/docs/segments/seg00155.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1d1</title>
+  <title>Segment: Handshape S1d1</title>
   
 <style>
 @font-face {
@@ -12,258 +12,472 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1d1</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00155</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersNonfist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(thumb flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1d1</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񄹱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1d1</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00155</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw">S1d1</td>
+<td class="signwriting col-signwriting-1">񄹱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
-<td>American Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00001.html">ASL (LQ_1)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00156.html
+++ b/docs/segments/seg00156.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1d2</title>
+  <title>Segment: Handshape S1d2</title>
   
 <style>
 @font-face {
@@ -12,213 +12,427 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1d2</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00156</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersNonfist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(thumb flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1d2</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񄻑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1d2</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00156</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw">S1d2</td>
+<td class="signwriting col-signwriting-1">񄻑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
-<td>Israeli Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
+<td class="col-language">Israeli Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00157.html
+++ b/docs/segments/seg00157.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1d3</title>
+  <title>Segment: Handshape S1d3</title>
   
 <style>
 @font-face {
@@ -12,163 +12,377 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1d3</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00157</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersNonfist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(thumb flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1d3</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񄼱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1d3</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00157</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw">S1d3</td>
+<td class="signwriting col-signwriting-1">񄼱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00158.html
+++ b/docs/segments/seg00158.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1d4</title>
+  <title>Segment: Handshape S1d4</title>
   
 <style>
 @font-face {
@@ -12,313 +12,527 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1d4</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00158</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersNonfist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(thumb flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1d4</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񄾑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1d4</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00158</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw">S1d4</td>
+<td class="signwriting col-signwriting-1">񄾑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
-<td>British Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00006.html">BSL (LQ_6)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00007.html">Auslan (LQ_7)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00008.html">NZSL (LQ_8)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
-<td>Danish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00011.html">DSL, DTS (LQ_11)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00074.html">PSL (SP_87)</a></td>
-<td>Pakistan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00074.html">PSL (SP_87)</a></td>
+<td class="col-language">Pakistan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00159.html
+++ b/docs/segments/seg00159.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1d8</title>
+  <title>Segment: Handshape S1d8</title>
   
 <style>
 @font-face {
@@ -12,163 +12,377 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1d8</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00159</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersNonfist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>(thumb flattened)</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1d8</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񅄑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1d8</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00159</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">(thumb flattened)</td>
+<td class="col-fsw">S1d8</td>
+<td class="signwriting col-signwriting-1">񅄑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
-<td>Swedish Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00005.html">SSL, STS (LQ_5)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
-<td>Greek Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
+<td class="col-language">Greek Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00058.html">KSL, LAK (SP_79)</a></td>
-<td>Kenya-Somali Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00058.html">KSL, LAK (SP_79)</a></td>
+<td class="col-language">Kenya-Somali Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
-<td>Swedish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00081.html">SSL, STS (SP_73)</a></td>
+<td class="col-language">Swedish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00160.html
+++ b/docs/segments/seg00160.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S105</title>
+  <title>Segment: Handshape S105</title>
   
 <style>
 @font-face {
@@ -12,168 +12,382 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S105</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00160</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersNonfist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>FlattenedandInFistfingerUp</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S105</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񀇱</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S105</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00160</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw">S105</td>
+<td class="signwriting col-signwriting-1">񀇱</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00012.html">NGT, SLN (LQ_12)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
-<td>Greek Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
+<td class="col-language">Greek Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
-<td>Israeli Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
+<td class="col-language">Israeli Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
-<td>Jordanian Sign Language or Levantine Arabic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
+<td class="col-language">Jordanian Sign Language or Levantine Arabic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00161.html
+++ b/docs/segments/seg00161.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S196</title>
+  <title>Segment: Handshape S196</title>
   
 <style>
 @font-face {
@@ -12,108 +12,322 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S196</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00161</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td>Thumb Opposition</td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td>1fin_othersNonfist</td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td>FlattenedandInFistfingerUp</td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S196</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting">񃡑</td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S196</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00161</td>
+<td class="col-hamnosys-1-initial-configuration">Thumb Opposition</td>
+<td class="col-hamnosys-2-basic-handshape">1fin_othersNonfist</td>
+<td class="col-hamnosys-3-handshape-modifications">FlattenedandInFistfingerUp</td>
+<td class="col-fsw">S196</td>
+<td class="signwriting col-signwriting-1">񃡑</td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Longqian Ming (2024)</td>
+<td class="col-inventory"><a href="../inventories/inv00009.html">TSL (LQ_9)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Longqian Ming (2024)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00162.html
+++ b/docs/segments/seg00162.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S10b</title>
+  <title>Segment: Handshape S10b</title>
   
 <style>
 @font-face {
@@ -12,228 +12,442 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S10b</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00162</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S10b</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S10b</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00162</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S10b</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00163.html
+++ b/docs/segments/seg00163.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S14a</title>
+  <title>Segment: Handshape S14a</title>
   
 <style>
 @font-face {
@@ -12,268 +12,482 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S14a</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00163</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S14a</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S14a</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00163</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S14a</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
-<td>Danish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00034.html">DSL, DTS (SP_30)</a></td>
+<td class="col-language">Danish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
-<td>Greek Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00045.html">ENG (SP_61)</a></td>
+<td class="col-language">Greek Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00164.html
+++ b/docs/segments/seg00164.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S14d</title>
+  <title>Segment: Handshape S14d</title>
   
 <style>
 @font-face {
@@ -12,158 +12,372 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S14d</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00164</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S14d</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S14d</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00164</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S14d</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00165.html
+++ b/docs/segments/seg00165.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S16f</title>
+  <title>Segment: Handshape S16f</title>
   
 <style>
 @font-face {
@@ -12,243 +12,457 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S16f</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00165</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S16f</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S16f</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00165</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S16f</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00058.html">KSL, LAK (SP_79)</a></td>
-<td>Kenya-Somali Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00058.html">KSL, LAK (SP_79)</a></td>
+<td class="col-language">Kenya-Somali Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00166.html
+++ b/docs/segments/seg00166.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S17e</title>
+  <title>Segment: Handshape S17e</title>
   
 <style>
 @font-face {
@@ -12,263 +12,477 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S17e</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00166</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S17e</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S17e</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00166</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S17e</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00167.html
+++ b/docs/segments/seg00167.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1cd</title>
+  <title>Segment: Handshape S1cd</title>
   
 <style>
 @font-face {
@@ -12,178 +12,392 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1cd</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00167</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1cd</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1cd</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00167</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1cd</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
-<td>Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00044.html">NISLs (SP_60)</a></td>
+<td class="col-language">Northern Irish Sign Languages (British Sign Language, Irish Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00168.html
+++ b/docs/segments/seg00168.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1dd</title>
+  <title>Segment: Handshape S1dd</title>
   
 <style>
 @font-face {
@@ -12,83 +12,297 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1dd</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00168</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1dd</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1dd</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00168</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1dd</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
-<td>Albanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00014.html">AlbSL (SP_82)</a></td>
+<td class="col-language">Albanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00169.html
+++ b/docs/segments/seg00169.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S102</title>
+  <title>Segment: Handshape S102</title>
   
 <style>
 @font-face {
@@ -12,113 +12,327 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S102</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00169</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S102</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S102</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00169</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S102</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00170.html
+++ b/docs/segments/seg00170.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S104</title>
+  <title>Segment: Handshape S104</title>
   
 <style>
 @font-face {
@@ -12,103 +12,317 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S104</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00170</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S104</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S104</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00170</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S104</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00171.html
+++ b/docs/segments/seg00171.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S107</title>
+  <title>Segment: Handshape S107</title>
   
 <style>
 @font-face {
@@ -12,138 +12,352 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S107</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00171</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S107</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S107</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00171</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S107</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00172.html
+++ b/docs/segments/seg00172.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S109</title>
+  <title>Segment: Handshape S109</title>
   
 <style>
 @font-face {
@@ -12,118 +12,332 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S109</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00172</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S109</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S109</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00172</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S109</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00173.html
+++ b/docs/segments/seg00173.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S10d</title>
+  <title>Segment: Handshape S10d</title>
   
 <style>
 @font-face {
@@ -12,128 +12,342 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S10d</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00173</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S10d</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S10d</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00173</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S10d</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00174.html
+++ b/docs/segments/seg00174.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S10f</title>
+  <title>Segment: Handshape S10f</title>
   
 <style>
 @font-face {
@@ -12,138 +12,352 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S10f</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00174</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S10f</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S10f</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00174</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S10f</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00175.html
+++ b/docs/segments/seg00175.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S111</title>
+  <title>Segment: Handshape S111</title>
   
 <style>
 @font-face {
@@ -12,88 +12,302 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S111</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00175</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S111</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S111</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00175</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S111</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00176.html
+++ b/docs/segments/seg00176.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S113</title>
+  <title>Segment: Handshape S113</title>
   
 <style>
 @font-face {
@@ -12,143 +12,357 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S113</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00176</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S113</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S113</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00176</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S113</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
-<td>Hungarian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
+<td class="col-language">Hungarian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00177.html
+++ b/docs/segments/seg00177.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S114</title>
+  <title>Segment: Handshape S114</title>
   
 <style>
 @font-face {
@@ -12,118 +12,332 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S114</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00177</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S114</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S114</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00177</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S114</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00178.html
+++ b/docs/segments/seg00178.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S117</title>
+  <title>Segment: Handshape S117</title>
   
 <style>
 @font-face {
@@ -12,93 +12,307 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S117</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00178</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S117</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S117</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00178</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S117</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00179.html
+++ b/docs/segments/seg00179.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S11b</title>
+  <title>Segment: Handshape S11b</title>
   
 <style>
 @font-face {
@@ -12,118 +12,332 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S11b</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00179</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S11b</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S11b</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00179</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S11b</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00180.html
+++ b/docs/segments/seg00180.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S11c</title>
+  <title>Segment: Handshape S11c</title>
   
 <style>
 @font-face {
@@ -12,108 +12,322 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S11c</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00180</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S11c</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S11c</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00180</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S11c</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00181.html
+++ b/docs/segments/seg00181.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S11f</title>
+  <title>Segment: Handshape S11f</title>
   
 <style>
 @font-face {
@@ -12,118 +12,332 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S11f</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00181</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S11f</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S11f</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00181</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S11f</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00182.html
+++ b/docs/segments/seg00182.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S120</title>
+  <title>Segment: Handshape S120</title>
   
 <style>
 @font-face {
@@ -12,83 +12,297 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S120</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00182</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S120</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S120</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00182</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S120</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00183.html
+++ b/docs/segments/seg00183.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S124</title>
+  <title>Segment: Handshape S124</title>
   
 <style>
 @font-face {
@@ -12,128 +12,342 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S124</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00183</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S124</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S124</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00183</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S124</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00184.html
+++ b/docs/segments/seg00184.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S12c</title>
+  <title>Segment: Handshape S12c</title>
   
 <style>
 @font-face {
@@ -12,103 +12,317 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S12c</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00184</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S12c</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S12c</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00184</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S12c</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00185.html
+++ b/docs/segments/seg00185.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S12e</title>
+  <title>Segment: Handshape S12e</title>
   
 <style>
 @font-face {
@@ -12,113 +12,327 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S12e</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00185</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S12e</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S12e</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00185</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S12e</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00186.html
+++ b/docs/segments/seg00186.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S12f</title>
+  <title>Segment: Handshape S12f</title>
   
 <style>
 @font-face {
@@ -12,93 +12,307 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S12f</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00186</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S12f</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S12f</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00186</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S12f</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00187.html
+++ b/docs/segments/seg00187.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S130</title>
+  <title>Segment: Handshape S130</title>
   
 <style>
 @font-face {
@@ -12,78 +12,292 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S130</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00187</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S130</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S130</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00187</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S130</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00188.html
+++ b/docs/segments/seg00188.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S131</title>
+  <title>Segment: Handshape S131</title>
   
 <style>
 @font-face {
@@ -12,83 +12,297 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S131</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00188</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S131</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S131</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00188</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S131</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00189.html
+++ b/docs/segments/seg00189.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S133</title>
+  <title>Segment: Handshape S133</title>
   
 <style>
 @font-face {
@@ -12,143 +12,357 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S133</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00189</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S133</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S133</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00189</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S133</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00190.html
+++ b/docs/segments/seg00190.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S134</title>
+  <title>Segment: Handshape S134</title>
   
 <style>
 @font-face {
@@ -12,143 +12,357 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S134</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00190</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S134</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S134</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00190</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S134</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00191.html
+++ b/docs/segments/seg00191.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S135</title>
+  <title>Segment: Handshape S135</title>
   
 <style>
 @font-face {
@@ -12,108 +12,322 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S135</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00191</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S135</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S135</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00191</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S135</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00192.html
+++ b/docs/segments/seg00192.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S136</title>
+  <title>Segment: Handshape S136</title>
   
 <style>
 @font-face {
@@ -12,93 +12,307 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S136</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00192</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S136</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S136</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00192</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S136</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00193.html
+++ b/docs/segments/seg00193.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S137</title>
+  <title>Segment: Handshape S137</title>
   
 <style>
 @font-face {
@@ -12,103 +12,317 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S137</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00193</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S137</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S137</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00193</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S137</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00194.html
+++ b/docs/segments/seg00194.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S138</title>
+  <title>Segment: Handshape S138</title>
   
 <style>
 @font-face {
@@ -12,123 +12,337 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S138</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00194</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S138</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S138</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00194</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S138</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00195.html
+++ b/docs/segments/seg00195.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S139</title>
+  <title>Segment: Handshape S139</title>
   
 <style>
 @font-face {
@@ -12,83 +12,297 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S139</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00195</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S139</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S139</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00195</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S139</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00196.html
+++ b/docs/segments/seg00196.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S13a</title>
+  <title>Segment: Handshape S13a</title>
   
 <style>
 @font-face {
@@ -12,83 +12,297 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S13a</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00196</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S13a</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S13a</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00196</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S13a</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00197.html
+++ b/docs/segments/seg00197.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S13b</title>
+  <title>Segment: Handshape S13b</title>
   
 <style>
 @font-face {
@@ -12,78 +12,292 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S13b</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00197</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S13b</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S13b</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00197</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S13b</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00198.html
+++ b/docs/segments/seg00198.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S13c</title>
+  <title>Segment: Handshape S13c</title>
   
 <style>
 @font-face {
@@ -12,88 +12,302 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S13c</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00198</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S13c</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S13c</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00198</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S13c</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00199.html
+++ b/docs/segments/seg00199.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S141</title>
+  <title>Segment: Handshape S141</title>
   
 <style>
 @font-face {
@@ -12,103 +12,317 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S141</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00199</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S141</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S141</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00199</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S141</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00200.html
+++ b/docs/segments/seg00200.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S143</title>
+  <title>Segment: Handshape S143</title>
   
 <style>
 @font-face {
@@ -12,88 +12,302 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S143</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00200</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S143</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S143</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00200</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S143</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00201.html
+++ b/docs/segments/seg00201.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S148</title>
+  <title>Segment: Handshape S148</title>
   
 <style>
 @font-face {
@@ -12,83 +12,297 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S148</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00201</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S148</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S148</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00201</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S148</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00202.html
+++ b/docs/segments/seg00202.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S14f</title>
+  <title>Segment: Handshape S14f</title>
   
 <style>
 @font-face {
@@ -12,148 +12,362 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S14f</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00202</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S14f</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S14f</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00202</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S14f</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00203.html
+++ b/docs/segments/seg00203.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S151</title>
+  <title>Segment: Handshape S151</title>
   
 <style>
 @font-face {
@@ -12,163 +12,377 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S151</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00203</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S151</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S151</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00203</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S151</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00204.html
+++ b/docs/segments/seg00204.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S152</title>
+  <title>Segment: Handshape S152</title>
   
 <style>
 @font-face {
@@ -12,238 +12,452 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S152</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00204</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S152</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S152</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00204</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S152</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00205.html
+++ b/docs/segments/seg00205.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S156</title>
+  <title>Segment: Handshape S156</title>
   
 <style>
 @font-face {
@@ -12,208 +12,422 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S156</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00205</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S156</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S156</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00205</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S156</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
-<td>Israeli Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
+<td class="col-language">Israeli Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00206.html
+++ b/docs/segments/seg00206.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S15b</title>
+  <title>Segment: Handshape S15b</title>
   
 <style>
 @font-face {
@@ -12,153 +12,367 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S15b</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00206</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S15b</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S15b</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00206</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S15b</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00207.html
+++ b/docs/segments/seg00207.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S15c</title>
+  <title>Segment: Handshape S15c</title>
   
 <style>
 @font-face {
@@ -12,148 +12,362 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S15c</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00207</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S15c</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S15c</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00207</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S15c</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00208.html
+++ b/docs/segments/seg00208.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S15e</title>
+  <title>Segment: Handshape S15e</title>
   
 <style>
 @font-face {
@@ -12,113 +12,327 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S15e</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00208</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S15e</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S15e</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00208</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S15e</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00209.html
+++ b/docs/segments/seg00209.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S15f</title>
+  <title>Segment: Handshape S15f</title>
   
 <style>
 @font-face {
@@ -12,148 +12,362 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S15f</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00209</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S15f</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S15f</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00209</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S15f</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00210.html
+++ b/docs/segments/seg00210.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S161</title>
+  <title>Segment: Handshape S161</title>
   
 <style>
 @font-face {
@@ -12,98 +12,312 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S161</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00210</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S161</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S161</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00210</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S161</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00211.html
+++ b/docs/segments/seg00211.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S162</title>
+  <title>Segment: Handshape S162</title>
   
 <style>
 @font-face {
@@ -12,108 +12,322 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S162</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00211</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S162</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S162</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00211</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S162</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00212.html
+++ b/docs/segments/seg00212.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S163</title>
+  <title>Segment: Handshape S163</title>
   
 <style>
 @font-face {
@@ -12,123 +12,337 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S163</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00212</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S163</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S163</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00212</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S163</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00213.html
+++ b/docs/segments/seg00213.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S164</title>
+  <title>Segment: Handshape S164</title>
   
 <style>
 @font-face {
@@ -12,83 +12,297 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S164</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00213</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S164</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S164</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00213</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S164</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00214.html
+++ b/docs/segments/seg00214.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S165</title>
+  <title>Segment: Handshape S165</title>
   
 <style>
 @font-face {
@@ -12,98 +12,312 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S165</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00214</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S165</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S165</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00214</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S165</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
-<td>Hungarian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
+<td class="col-language">Hungarian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00215.html
+++ b/docs/segments/seg00215.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S166</title>
+  <title>Segment: Handshape S166</title>
   
 <style>
 @font-face {
@@ -12,178 +12,392 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S166</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00215</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S166</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S166</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00215</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S166</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00216.html
+++ b/docs/segments/seg00216.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S167</title>
+  <title>Segment: Handshape S167</title>
   
 <style>
 @font-face {
@@ -12,183 +12,397 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S167</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00216</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S167</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S167</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00216</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S167</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00217.html
+++ b/docs/segments/seg00217.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S169</title>
+  <title>Segment: Handshape S169</title>
   
 <style>
 @font-face {
@@ -12,118 +12,332 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S169</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00217</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S169</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S169</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00217</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S169</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00218.html
+++ b/docs/segments/seg00218.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S16a</title>
+  <title>Segment: Handshape S16a</title>
   
 <style>
 @font-face {
@@ -12,93 +12,307 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S16a</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00218</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S16a</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S16a</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00218</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S16a</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00219.html
+++ b/docs/segments/seg00219.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S16b</title>
+  <title>Segment: Handshape S16b</title>
   
 <style>
 @font-face {
@@ -12,123 +12,337 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S16b</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00219</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S16b</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S16b</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00219</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S16b</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
-<td>Hungarian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00050.html">HSL (SP_122)</a></td>
+<td class="col-language">Hungarian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00220.html
+++ b/docs/segments/seg00220.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S16c</title>
+  <title>Segment: Handshape S16c</title>
   
 <style>
 @font-face {
@@ -12,238 +12,452 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S16c</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00220</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S16c</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S16c</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00220</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S16c</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00221.html
+++ b/docs/segments/seg00221.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S172</title>
+  <title>Segment: Handshape S172</title>
   
 <style>
 @font-face {
@@ -12,153 +12,367 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S172</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00221</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S172</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S172</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00221</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S172</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00222.html
+++ b/docs/segments/seg00222.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S174</title>
+  <title>Segment: Handshape S174</title>
   
 <style>
 @font-face {
@@ -12,158 +12,372 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S174</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00222</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S174</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S174</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00222</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S174</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00223.html
+++ b/docs/segments/seg00223.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S175</title>
+  <title>Segment: Handshape S175</title>
   
 <style>
 @font-face {
@@ -12,168 +12,382 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S175</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00223</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S175</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S175</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00223</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S175</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00224.html
+++ b/docs/segments/seg00224.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S178</title>
+  <title>Segment: Handshape S178</title>
   
 <style>
 @font-face {
@@ -12,178 +12,392 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S178</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00224</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S178</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S178</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00224</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S178</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00225.html
+++ b/docs/segments/seg00225.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S179</title>
+  <title>Segment: Handshape S179</title>
   
 <style>
 @font-face {
@@ -12,173 +12,387 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S179</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00225</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S179</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S179</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00225</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S179</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00226.html
+++ b/docs/segments/seg00226.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S17a</title>
+  <title>Segment: Handshape S17a</title>
   
 <style>
 @font-face {
@@ -12,138 +12,352 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S17a</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00226</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S17a</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S17a</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00226</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S17a</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00227.html
+++ b/docs/segments/seg00227.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S17b</title>
+  <title>Segment: Handshape S17b</title>
   
 <style>
 @font-face {
@@ -12,178 +12,392 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S17b</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00227</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S17b</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S17b</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00227</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S17b</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
-<td>Romanian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00078.html">LSR (SP_132)</a></td>
+<td class="col-language">Romanian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00228.html
+++ b/docs/segments/seg00228.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S17f</title>
+  <title>Segment: Handshape S17f</title>
   
 <style>
 @font-face {
@@ -12,203 +12,417 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S17f</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00228</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S17f</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S17f</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00228</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S17f</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00229.html
+++ b/docs/segments/seg00229.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S181</title>
+  <title>Segment: Handshape S181</title>
   
 <style>
 @font-face {
@@ -12,238 +12,452 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S181</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00229</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S181</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S181</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00229</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S181</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
-<td>Malawian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00063.html">MSL (SP_128)</a></td>
+<td class="col-language">Malawian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00230.html
+++ b/docs/segments/seg00230.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S183</title>
+  <title>Segment: Handshape S183</title>
   
 <style>
 @font-face {
@@ -12,148 +12,362 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S183</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00230</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S183</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S183</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00230</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S183</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00231.html
+++ b/docs/segments/seg00231.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S184</title>
+  <title>Segment: Handshape S184</title>
   
 <style>
 @font-face {
@@ -12,93 +12,307 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S184</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00231</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S184</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S184</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00231</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S184</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00232.html
+++ b/docs/segments/seg00232.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S186</title>
+  <title>Segment: Handshape S186</title>
   
 <style>
 @font-face {
@@ -12,283 +12,497 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S186</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00232</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S186</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S186</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00232</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S186</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
-<td>Dutch Sign Language or Sign Language of the Netherlands</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00068.html">NGT, SLN (SP_68)</a></td>
+<td class="col-language">Dutch Sign Language or Sign Language of the Netherlands</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00233.html
+++ b/docs/segments/seg00233.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S188</title>
+  <title>Segment: Handshape S188</title>
   
 <style>
 @font-face {
@@ -12,108 +12,322 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S188</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00233</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S188</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S188</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00233</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S188</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00234.html
+++ b/docs/segments/seg00234.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S189</title>
+  <title>Segment: Handshape S189</title>
   
 <style>
 @font-face {
@@ -12,128 +12,342 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S189</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00234</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S189</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S189</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00234</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S189</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00235.html
+++ b/docs/segments/seg00235.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S18a</title>
+  <title>Segment: Handshape S18a</title>
   
 <style>
 @font-face {
@@ -12,103 +12,317 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S18a</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00235</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S18a</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S18a</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00235</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S18a</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00236.html
+++ b/docs/segments/seg00236.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S191</title>
+  <title>Segment: Handshape S191</title>
   
 <style>
 @font-face {
@@ -12,88 +12,302 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S191</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00236</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S191</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S191</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00236</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S191</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00237.html
+++ b/docs/segments/seg00237.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S194</title>
+  <title>Segment: Handshape S194</title>
   
 <style>
 @font-face {
@@ -12,103 +12,317 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S194</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00237</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S194</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S194</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00237</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S194</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00238.html
+++ b/docs/segments/seg00238.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S195</title>
+  <title>Segment: Handshape S195</title>
   
 <style>
 @font-face {
@@ -12,83 +12,297 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S195</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00238</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S195</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S195</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00238</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S195</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00239.html
+++ b/docs/segments/seg00239.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S197</title>
+  <title>Segment: Handshape S197</title>
   
 <style>
 @font-face {
@@ -12,88 +12,302 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S197</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00239</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S197</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S197</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00239</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S197</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00240.html
+++ b/docs/segments/seg00240.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S19b</title>
+  <title>Segment: Handshape S19b</title>
   
 <style>
 @font-face {
@@ -12,123 +12,337 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S19b</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00240</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S19b</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S19b</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00240</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S19b</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00241.html
+++ b/docs/segments/seg00241.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S19d</title>
+  <title>Segment: Handshape S19d</title>
   
 <style>
 @font-face {
@@ -12,163 +12,377 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S19d</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00241</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S19d</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S19d</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00241</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S19d</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00242.html
+++ b/docs/segments/seg00242.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S19e</title>
+  <title>Segment: Handshape S19e</title>
   
 <style>
 @font-face {
@@ -12,83 +12,297 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S19e</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00242</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S19e</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S19e</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00242</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S19e</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00243.html
+++ b/docs/segments/seg00243.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1a1</title>
+  <title>Segment: Handshape S1a1</title>
   
 <style>
 @font-face {
@@ -12,138 +12,352 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1a1</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00243</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1a1</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1a1</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00243</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1a1</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00244.html
+++ b/docs/segments/seg00244.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1a2</title>
+  <title>Segment: Handshape S1a2</title>
   
 <style>
 @font-face {
@@ -12,98 +12,312 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1a2</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00244</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1a2</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1a2</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00244</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1a2</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00245.html
+++ b/docs/segments/seg00245.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1a6</title>
+  <title>Segment: Handshape S1a6</title>
   
 <style>
 @font-face {
@@ -12,113 +12,327 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1a6</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00245</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1a6</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1a6</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00245</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1a6</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00246.html
+++ b/docs/segments/seg00246.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1a8</title>
+  <title>Segment: Handshape S1a8</title>
   
 <style>
 @font-face {
@@ -12,133 +12,347 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1a8</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00246</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1a8</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1a8</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00246</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1a8</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00247.html
+++ b/docs/segments/seg00247.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1a9</title>
+  <title>Segment: Handshape S1a9</title>
   
 <style>
 @font-face {
@@ -12,88 +12,302 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1a9</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00247</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1a9</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1a9</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00247</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1a9</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00248.html
+++ b/docs/segments/seg00248.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1aa</title>
+  <title>Segment: Handshape S1aa</title>
   
 <style>
 @font-face {
@@ -12,83 +12,297 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1aa</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00248</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1aa</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1aa</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00248</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1aa</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00249.html
+++ b/docs/segments/seg00249.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1ac</title>
+  <title>Segment: Handshape S1ac</title>
   
 <style>
 @font-face {
@@ -12,78 +12,292 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1ac</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00249</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1ac</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1ac</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00249</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1ac</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00250.html
+++ b/docs/segments/seg00250.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1af</title>
+  <title>Segment: Handshape S1af</title>
   
 <style>
 @font-face {
@@ -12,83 +12,297 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1af</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00250</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1af</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1af</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00250</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1af</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00251.html
+++ b/docs/segments/seg00251.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1b1</title>
+  <title>Segment: Handshape S1b1</title>
   
 <style>
 @font-face {
@@ -12,93 +12,307 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1b1</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00251</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1b1</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1b1</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00251</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1b1</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
-<td>Chinese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00029.html">CSL, ZGS (SP_83)</a></td>
+<td class="col-language">Chinese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00252.html
+++ b/docs/segments/seg00252.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1b6</title>
+  <title>Segment: Handshape S1b6</title>
   
 <style>
 @font-face {
@@ -12,78 +12,292 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1b6</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00252</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1b6</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1b6</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00252</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1b6</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00253.html
+++ b/docs/segments/seg00253.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1b7</title>
+  <title>Segment: Handshape S1b7</title>
   
 <style>
 @font-face {
@@ -12,98 +12,312 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1b7</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00253</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1b7</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1b7</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00253</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1b7</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00254.html
+++ b/docs/segments/seg00254.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1b8</title>
+  <title>Segment: Handshape S1b8</title>
   
 <style>
 @font-face {
@@ -12,103 +12,317 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1b8</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00254</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1b8</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1b8</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00254</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1b8</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00255.html
+++ b/docs/segments/seg00255.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1b9</title>
+  <title>Segment: Handshape S1b9</title>
   
 <style>
 @font-face {
@@ -12,83 +12,297 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1b9</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00255</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1b9</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1b9</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00255</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1b9</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00256.html
+++ b/docs/segments/seg00256.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1bc</title>
+  <title>Segment: Handshape S1bc</title>
   
 <style>
 @font-face {
@@ -12,138 +12,352 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1bc</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00256</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1bc</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1bc</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00256</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1bc</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00257.html
+++ b/docs/segments/seg00257.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1bd</title>
+  <title>Segment: Handshape S1bd</title>
   
 <style>
 @font-face {
@@ -12,93 +12,307 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1bd</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00257</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1bd</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1bd</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00257</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1bd</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00258.html
+++ b/docs/segments/seg00258.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1be</title>
+  <title>Segment: Handshape S1be</title>
   
 <style>
 @font-face {
@@ -12,83 +12,297 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1be</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00258</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1be</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1be</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00258</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1be</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00259.html
+++ b/docs/segments/seg00259.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1bf</title>
+  <title>Segment: Handshape S1bf</title>
   
 <style>
 @font-face {
@@ -12,98 +12,312 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1bf</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00259</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1bf</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1bf</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00259</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1bf</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00260.html
+++ b/docs/segments/seg00260.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1c0</title>
+  <title>Segment: Handshape S1c0</title>
   
 <style>
 @font-face {
@@ -12,123 +12,337 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1c0</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00260</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1c0</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1c0</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00260</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1c0</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00261.html
+++ b/docs/segments/seg00261.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1c2</title>
+  <title>Segment: Handshape S1c2</title>
   
 <style>
 @font-face {
@@ -12,123 +12,337 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1c2</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00261</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1c2</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1c2</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00261</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1c2</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00262.html
+++ b/docs/segments/seg00262.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1c7</title>
+  <title>Segment: Handshape S1c7</title>
   
 <style>
 @font-face {
@@ -12,83 +12,297 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1c7</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00262</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1c7</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1c7</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00262</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1c7</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00263.html
+++ b/docs/segments/seg00263.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1c8</title>
+  <title>Segment: Handshape S1c8</title>
   
 <style>
 @font-face {
@@ -12,88 +12,302 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1c8</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00263</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1c8</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1c8</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00263</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1c8</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00264.html
+++ b/docs/segments/seg00264.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1c9</title>
+  <title>Segment: Handshape S1c9</title>
   
 <style>
 @font-face {
@@ -12,108 +12,322 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1c9</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00264</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1c9</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1c9</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00264</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1c9</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
-<td>Jordanian Sign Language or Levantine Arabic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
+<td class="col-language">Jordanian Sign Language or Levantine Arabic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00265.html
+++ b/docs/segments/seg00265.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1ca</title>
+  <title>Segment: Handshape S1ca</title>
   
 <style>
 @font-face {
@@ -12,98 +12,312 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1ca</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00265</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1ca</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1ca</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00265</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1ca</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00266.html
+++ b/docs/segments/seg00266.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1cc</title>
+  <title>Segment: Handshape S1cc</title>
   
 <style>
 @font-face {
@@ -12,88 +12,302 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1cc</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00266</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1cc</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1cc</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00266</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1cc</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00267.html
+++ b/docs/segments/seg00267.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1cf</title>
+  <title>Segment: Handshape S1cf</title>
   
 <style>
 @font-face {
@@ -12,193 +12,407 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1cf</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00267</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1cf</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1cf</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00267</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1cf</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
-<td>Ethiopian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00040.html">EthSL (SP_18)</a></td>
+<td class="col-language">Ethiopian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00268.html
+++ b/docs/segments/seg00268.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1d9</title>
+  <title>Segment: Handshape S1d9</title>
   
 <style>
 @font-face {
@@ -12,108 +12,322 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1d9</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00268</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1d9</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1d9</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00268</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1d9</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00269.html
+++ b/docs/segments/seg00269.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1db</title>
+  <title>Segment: Handshape S1db</title>
   
 <style>
 @font-face {
@@ -12,118 +12,332 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1db</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00269</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1db</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1db</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00269</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1db</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00270.html
+++ b/docs/segments/seg00270.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1e3</title>
+  <title>Segment: Handshape S1e3</title>
   
 <style>
 @font-face {
@@ -12,133 +12,347 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1e3</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00270</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1e3</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1e3</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00270</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1e3</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
-<td>Israeli Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00052.html">Shassi, ISL (SP_110)</a></td>
+<td class="col-language">Israeli Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00271.html
+++ b/docs/segments/seg00271.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1e6</title>
+  <title>Segment: Handshape S1e6</title>
   
 <style>
 @font-face {
@@ -12,153 +12,367 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1e6</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00271</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1e6</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1e6</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00271</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1e6</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00272.html
+++ b/docs/segments/seg00272.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1e8</title>
+  <title>Segment: Handshape S1e8</title>
   
 <style>
 @font-face {
@@ -12,128 +12,342 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1e8</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00272</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1e8</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1e8</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00272</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1e8</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00273.html
+++ b/docs/segments/seg00273.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1ec</title>
+  <title>Segment: Handshape S1ec</title>
   
 <style>
 @font-face {
@@ -12,278 +12,492 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1ec</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00273</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1ec</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1ec</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00273</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1ec</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
-<td>Jordanian Sign Language or Levantine Arabic Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00056.html">LIU (SP_86)</a></td>
+<td class="col-language">Jordanian Sign Language or Levantine Arabic Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
-<td>Japanese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00057.html">JSL (SP_64)</a></td>
+<td class="col-language">Japanese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
-<td>New Zealand Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00071.html">NZSL (SP_70)</a></td>
+<td class="col-language">New Zealand Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
-<td>Russian-Tajik Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00079.html">RSL (SP_88)</a></td>
+<td class="col-language">Russian-Tajik Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
-<td>Ukrainian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">USL, UZhM (SP_130)</a></td>
+<td class="col-language">Ukrainian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
-<td>Uruguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00089.html">LSU (SP_143)</a></td>
+<td class="col-language">Uruguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00274.html
+++ b/docs/segments/seg00274.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1ef</title>
+  <title>Segment: Handshape S1ef</title>
   
 <style>
 @font-face {
@@ -12,248 +12,462 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1ef</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00274</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1ef</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1ef</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00274</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1ef</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
-<td>French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00018.html">LSFB (SP_43)</a></td>
+<td class="col-language">French Belgian Sign Language (Langue des signes de Belgique Francophone)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
-<td>Chilean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00028.html">LSCh (SP_135)</a></td>
+<td class="col-language">Chilean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
-<td>French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00042.html">LSF (SP_58)</a></td>
+<td class="col-language">French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
-<td>Venezuelan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00090.html">VSL (SP_76)</a></td>
+<td class="col-language">Venezuelan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
-<td>Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">VSLs (SP_153)</a></td>
+<td class="col-language">Vietnamese Sign Languages (Haiphong Sign Language, Hanoi Sign Language, Ho Chi Minh City Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
-<td>International Sign</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00091.html">IS (SP_35)</a></td>
+<td class="col-language">International Sign</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00275.html
+++ b/docs/segments/seg00275.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1f1</title>
+  <title>Segment: Handshape S1f1</title>
   
 <style>
 @font-face {
@@ -12,228 +12,442 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1f1</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00275</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1f1</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1f1</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00275</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1f1</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
-<td>Argentine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00015.html">LSA (SP_41)</a></td>
+<td class="col-language">Argentine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
-<td>Nicaraguan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00067.html">ISN (SP_67)</a></td>
+<td class="col-language">Nicaraguan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
-<td>Peruvian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00072.html">LSP (SP_71)</a></td>
+<td class="col-language">Peruvian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
-<td>Polish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00075.html">PJM (SP_19)</a></td>
+<td class="col-language">Polish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
-<td>Portuguese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00076.html">LGP (SP_33)</a></td>
+<td class="col-language">Portuguese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
-<td>Singapore Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00082.html">SgSL (SP_11)</a></td>
+<td class="col-language">Singapore Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
-<td>Esperanto-SignUno</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00093.html">Signuno (SP_54)</a></td>
+<td class="col-language">Esperanto-SignUno</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00276.html
+++ b/docs/segments/seg00276.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1f6</title>
+  <title>Segment: Handshape S1f6</title>
   
 <style>
 @font-face {
@@ -12,138 +12,352 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1f6</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00276</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1f6</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1f6</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00276</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1f6</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
-<td>South African Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00092.html">SASL (SP_77)</a></td>
+<td class="col-language">South African Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
-<td>Yugoslavian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00094.html">YSL (SP_74)</a></td>
+<td class="col-language">Yugoslavian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00277.html
+++ b/docs/segments/seg00277.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1fa</title>
+  <title>Segment: Handshape S1fa</title>
   
 <style>
 @font-face {
@@ -12,208 +12,422 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1fa</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00277</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1fa</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1fa</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00277</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1fa</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
-<td>Auslan (Australian Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00017.html">Auslan (SP_42)</a></td>
+<td class="col-language">Auslan (Australian Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
-<td>Flemish Sign Language (Vlaamse Gebarentaal)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00019.html">VGT (SP_44)</a></td>
+<td class="col-language">Flemish Sign Language (Vlaamse Gebarentaal)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
-<td>Brazilian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00022.html">Libras (SP_46)</a></td>
+<td class="col-language">Brazilian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
-<td>American Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00023.html">ASL (SP_4)</a></td>
+<td class="col-language">American Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
-<td>Swiss-German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00025.html">DSGS (SP_48)</a></td>
+<td class="col-language">Swiss-German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
-<td>Swiss-French Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00026.html">LSF-SR (SP_49)</a></td>
+<td class="col-language">Swiss-French Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
-<td>Colombian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00030.html">LSC (CO) (SP_51)</a></td>
+<td class="col-language">Colombian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
-<td>Czech Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00032.html">ČZJ (SP_52)</a></td>
+<td class="col-language">Czech Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
-<td>German Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00033.html">DGS (SP_53)</a></td>
+<td class="col-language">German Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
-<td>Spanish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00038.html">LSE (SP_55)</a></td>
+<td class="col-language">Spanish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
-<td>Catalan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00039.html">LSC (CT) (SP_56)</a></td>
+<td class="col-language">Catalan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
-<td>Finnish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00041.html">FinSL (SP_57)</a></td>
+<td class="col-language">Finnish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
-<td>British Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00043.html">BSL (SP_59)</a></td>
+<td class="col-language">British Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
-<td>Italian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00055.html">LIS (SP_63)</a></td>
+<td class="col-language">Italian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
-<td>Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">MSLs (SP_2)</a></td>
+<td class="col-language">Myanmar Sign Languages or Burmese Sign Languages (Mandalay Myanmar Sign Language, Yangon Myanmar Sign Language)</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
-<td>Maltese Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00062.html">LSM (MT) (SP_31)</a></td>
+<td class="col-language">Maltese Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
-<td>Mexican Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00064.html">LSM (MX) (SP_65)</a></td>
+<td class="col-language">Mexican Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
-<td>Norwegian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00069.html">NTS, NSL (SP_69)</a></td>
+<td class="col-language">Norwegian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
-<td>Paraguayan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00077.html">LSPy (SP_129)</a></td>
+<td class="col-language">Paraguayan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
-<td>Saudi Sign Language or Saudi Arabian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00080.html">SSL, SASL (SP_40)</a></td>
+<td class="col-language">Saudi Sign Language or Saudi Arabian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
-<td>Thai Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00085.html">TSL, MSTSL (SP_34)</a></td>
+<td class="col-language">Thai Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
-<td>Tunisian Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00086.html">TunSL (SP_104)</a></td>
+<td class="col-language">Tunisian Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
-<td>Taiwan Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00088.html">TSL (SP_75)</a></td>
+<td class="col-language">Taiwan Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/docs/segments/seg00278.html
+++ b/docs/segments/seg00278.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Handshape S1fe</title>
+  <title>Segment: Handshape S1fe</title>
   
 <style>
 @font-face {
@@ -12,98 +12,312 @@
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 
 </head>
 <body>
-  <h1>Handshape S1fe</h1>
+  <main class="page">
+    
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
 
-  <h2>Segment Details</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
-<tbody>
-<tr>
-<th>Segment Id</th>
-<td>seg00278</td>
-</tr>
-<tr>
-<th>Segment Class</th>
-<td>handshape</td>
-</tr>
-<tr>
-<th>Hamnosys 1 Initial Configuration</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 2 Basic Handshape</th>
-<td></td>
-</tr>
-<tr>
-<th>Hamnosys 3 Handshape Modifications</th>
-<td></td>
-</tr>
-<tr>
-<th>Fsw</th>
-<td>S1fe</td>
-</tr>
-<tr>
-<th>Signwriting 1</th>
-<td class="signwriting"></td>
-</tr>
-<tr>
-<th>Signwriting 2</th>
-<td class="signwriting"></td>
-</tr>
-</tbody></table>
 
-  <h2>Inventories Containing This Segment</h2>
-  <table border='1' cellspacing='0' cellpadding='6'>
+    <section class="content-card">
+      <h1>Segment: Handshape S1fe</h1>
+      <div class="metadata-table-container">
+<table class="metadata-table">
 <thead><tr>
-<th>Inventory</th>
-<th>Language</th>
-<th>Source</th>
+<th class="col-segment-id">Segment Id</th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-fsw">FSW</th>
+<th class="col-signwriting-1">Signwriting 1</th>
+<th class="col-signwriting-2">Signwriting 2</th>
+</tr></thead>
+<tbody><tr>
+<td class="col-segment-id">seg00278</td>
+<td class="col-hamnosys-1-initial-configuration"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-2-basic-handshape"><span class="empty-cell">—</span></td>
+<td class="col-hamnosys-3-handshape-modifications"><span class="empty-cell">—</span></td>
+<td class="col-fsw">S1fe</td>
+<td class="signwriting col-signwriting-1"><span class="empty-cell">—</span></td>
+<td class="signwriting col-signwriting-2"><span class="empty-cell">—</span></td>
+</tr></tbody>
+</table>
+</div>
+      <p class="page-description">This page lists the details for a single segment and the inventories that contain it.</p>
+    </section>
+
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      <input id="table-search" class="table-search" type="search" placeholder="Type to filter rows...">
+<div class="table-container">
+<table class="filterable-table">
+<thead><tr>
+<th class="col-inventory">Inventory</th>
+<th class="col-language">Language</th>
+<th class="col-source">Source</th>
 </tr></thead>
 <tbody>
 <tr>
-<td><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
-<td>Quebec Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00024.html">LSQ (SP_47)</a></td>
+<td class="col-language">Quebec Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
-<td>Honduras Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00048.html">LESHO (SP_16)</a></td>
+<td class="col-language">Honduras Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
-<td>Irish Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00051.html">ISL (IE) (SP_62)</a></td>
+<td class="col-language">Irish Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
-<td>Korean Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00059.html">KSL (SP_78)</a></td>
+<td class="col-language">Korean Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 <tr>
-<td><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
-<td>Philippine Sign Language</td>
-<td>Luz Diaz (2025)</td>
+<td class="col-inventory"><a href="../inventories/inv00073.html">FSL (SP_72)</a></td>
+<td class="col-language">Philippine Sign Language</td>
+<td class="col-source">Luz Diaz (2025)</td>
 </tr>
 </tbody></table>
+</div>
+    </section>
+  </main>
+  
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+
 </body>
 </html>

--- a/scripts/pages/ibuilder.py
+++ b/scripts/pages/ibuilder.py
@@ -5,7 +5,7 @@ import sys
 
 csv.field_size_limit(sys.maxsize)
 
-SIGNWRITING_FONT_CSS = """
+PAGE_CSS = """
 <style>
 @font-face {
   font-family: "SuttonSignWritingLine";
@@ -13,24 +13,241 @@ SIGNWRITING_FONT_CSS = """
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.page-description em {
+  color: #555;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.metadata-table .col-inventory-id {
+  white-space: nowrap;
+}
+
+.metadata-table .col-language-name,
+.metadata-table .col-contributor {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
 """
+
+TABLE_FILTER_SCRIPT = """
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+"""
+
 
 def load_csv(csv_path):
     with open(csv_path, newline="", encoding="utf-8") as f:
@@ -39,18 +256,51 @@ def load_csv(csv_path):
 
 def show_columns(columns):
     print("\nAvailable columns:")
+
     for i, col in enumerate(columns, start=1):
         print(f"{i}. {col}")
 
 
-def choose_columns(columns, prompt, allow_none=False):
-    print(f"\n{prompt}")
-    if allow_none:
-        print("Enter column numbers separated by commas, or 0 for none.")
-    else:
-        print("Enter column numbers separated by commas.")
+def format_columns_with_numbers(columns, selected_columns):
+    formatted_columns = []
 
-    raw = input("> ").strip()
+    for selected_column in selected_columns:
+        column_number = columns.index(selected_column) + 1
+        formatted_columns.append(f"{column_number}. {selected_column}")
+
+    return ", ".join(formatted_columns)
+
+
+def format_column_with_number(columns, selected_column):
+    column_number = columns.index(selected_column) + 1
+    return f"{column_number}. {selected_column}"
+
+
+def prompt_with_default(label, default_value):
+    value = input(
+        f"\n{label} [{default_value}] (Enter = default): "
+    ).strip()
+
+    if value == "":
+        return default_value
+
+    return value
+
+
+def prompt_columns_with_default(columns, label, default_columns, allow_none=False):
+    default_text = format_columns_with_numbers(columns, default_columns)
+
+    if allow_none:
+        raw = input(
+            f"\n{label} [{default_text}] (Enter = default, type numbers, or 0 for none): "
+        ).strip()
+    else:
+        raw = input(
+            f"\n{label} [{default_text}] (Enter = default, or type numbers): "
+        ).strip()
+
+    if raw == "":
+        return default_columns
 
     if allow_none and raw == "0":
         return []
@@ -59,35 +309,78 @@ def choose_columns(columns, prompt, allow_none=False):
     return [columns[i] for i in indices]
 
 
-def choose_one_column(columns, prompt):
-    print(f"\n{prompt}")
-    raw = input("> ").strip()
+def prompt_column_with_default(columns, label, default_column):
+    default_text = format_column_with_number(columns, default_column)
+
+    raw = input(
+        f"\n{label} [{default_text}] (Enter = default, or type number): "
+    ).strip()
+
+    if raw == "":
+        return default_column
+
     return columns[int(raw) - 1]
+
+
+def find_column_case_insensitive(columns, target_name):
+    for column in columns:
+        if column.lower() == target_name.lower():
+            return column
+
+    return None
+
+
+def get_default_source_segment_column(family, source_columns):
+    family_defaults = {
+        "LQ": "FSW",
+        "SP": "Handshape",
+    }
+
+    default_column = family_defaults.get(family)
+
+    if default_column:
+        matched_column = find_column_case_insensitive(source_columns, default_column)
+
+        if matched_column:
+            return matched_column
+
+    fallback_column = find_column_case_insensitive(source_columns, "fsw")
+
+    if fallback_column:
+        return fallback_column
+
+    return source_columns[0]
 
 
 def find_matching_file(folder, source_code):
     folder_path = Path(folder)
     matches = list(folder_path.glob(f"{source_code}_*.csv"))
+
     if not matches:
         return None
+
     return matches[0]
 
 
 def build_segments_lookup(segments_rows, fsw_column, segment_id_column):
     lookup = {}
+
     for row in segments_rows:
         fsw = row.get(fsw_column, "").strip()
+
         if fsw:
             lookup[fsw] = dict(row)
             lookup[fsw]["segment_id"] = row.get(segment_id_column, "").strip()
+
     return lookup
 
 
-def join_inventory_rows(source_rows, source_fsw_column, segments_lookup, segment_columns_to_add):
+def join_inventory_rows(source_rows, source_segment_column, segments_lookup, segment_columns_to_add):
     joined = []
+
     for row in source_rows:
-        fsw_value = row.get(source_fsw_column, "").strip()
-        segment_row = segments_lookup.get(fsw_value, {})
+        segment_value = row.get(source_segment_column, "").strip()
+        segment_row = segments_lookup.get(segment_value, {})
 
         new_row = {"segment_id": segment_row.get("segment_id", "")}
 
@@ -102,89 +395,164 @@ def join_inventory_rows(source_rows, source_fsw_column, segments_lookup, segment
 def build_fsw_link(fsw_value, segment_id):
     if not segment_id:
         return html.escape(fsw_value)
+
     href = f"../segments/{segment_id}.html"
     return f'<a href="{html.escape(href)}">{html.escape(fsw_value)}</a>'
 
 
 def format_header(column_name):
-    return column_name.replace("_", " ").title()
+    special_headers = {
+        "fsw": "FSW",
+        "hamnosys_1_initial_configuration": "HamNoSys 1<br><span>Initial Configuration</span>",
+        "hamnosys_2_basic_handshape": "HamNoSys 2<br><span>Basic Handshape</span>",
+        "hamnosys_3_handshape_modifications": "HamNoSys 3<br><span>Handshape Modifications</span>",
+    }
+
+    if column_name in special_headers:
+        return special_headers[column_name]
+
+    return html.escape(column_name.replace("_", " ").title())
+
+
+def format_cell_value(value):
+    if value == "":
+        return '<span class="empty-cell">—</span>'
+
+    return html.escape(value)
+
+
+def column_class_name(column_name):
+    return f"col-{column_name.replace('_', '-').lower()}"
+
+
+def render_search_box():
+    return (
+        '<input id="table-search" class="table-search" type="search" '
+        'placeholder="Type to filter rows...">'
+    )
+
+
+def render_site_nav():
+    return """
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
+"""
 
 
 def render_table(rows, columns_to_show, fsw_column):
     parts = []
-    parts.append("<table border='1' cellspacing='0' cellpadding='6'>")
+    parts.append(render_search_box())
+    parts.append('<div class="table-container">')
+    parts.append('<table class="filterable-table">')
     parts.append("<thead><tr>")
 
     for col in columns_to_show:
-        parts.append(f"<th>{html.escape(format_header(col))}</th>")
+        column_class = column_class_name(col)
+        parts.append(f'<th class="{column_class}">{format_header(col)}</th>')
 
     parts.append("</tr></thead>")
     parts.append("<tbody>")
 
     for row in rows:
         parts.append("<tr>")
+
         for col in columns_to_show:
-            value = row.get(col, "")
+            value = row.get(col, "").strip()
+            column_class = column_class_name(col)
+
             if col == fsw_column:
                 cell = build_fsw_link(value, row.get("segment_id", ""))
             else:
-                cell = html.escape(value)
+                cell = format_cell_value(value)
 
             if col.startswith("signwriting"):
-                parts.append(f'<td class="signwriting">{cell}</td>')
+                parts.append(f'<td class="signwriting {column_class}">{cell}</td>')
             else:
-                parts.append(f"<td>{cell}</td>")
+                parts.append(f'<td class="{column_class}">{cell}</td>')
+
         parts.append("</tr>")
 
     parts.append("</tbody></table>")
+    parts.append("</div>")
+
     return "\n".join(parts)
 
 
 def render_inventory_metadata(inventory_row):
     wanted = [
         "inventory_id",
-        "inventory_name",
         "language_name",
-        "data_source",
         "contributor",
-        "cite",
+    ]
+
+    columns_to_show = [
+        key for key in wanted
+        if key in inventory_row
     ]
 
     parts = []
-    parts.append("<table border='1' cellspacing='0' cellpadding='6'>")
-    parts.append("<tbody>")
+    parts.append('<div class="metadata-table-container">')
+    parts.append('<table class="metadata-table">')
+    parts.append("<thead><tr>")
 
-    for key in wanted:
-        if key in inventory_row:
-            parts.append("<tr>")
-            parts.append(f"<th>{html.escape(format_header(key))}</th>")
-            parts.append(f"<td>{html.escape(inventory_row.get(key, ''))}</td>")
-            parts.append("</tr>")
+    for key in columns_to_show:
+        column_class = column_class_name(key)
+        parts.append(f'<th class="{column_class}">{format_header(key)}</th>')
 
-    parts.append("</tbody></table>")
+    parts.append("</tr></thead>")
+    parts.append("<tbody><tr>")
+
+    for key in columns_to_show:
+        value = inventory_row.get(key, "").strip()
+        column_class = column_class_name(key)
+        parts.append(f'<td class="{column_class}">{format_cell_value(value)}</td>')
+
+    parts.append("</tr></tbody>")
+    parts.append("</table>")
+    parts.append("</div>")
+
     return "\n".join(parts)
 
 
 def write_inventory_page(output_path, title, metadata_html, table_html):
+    description = "This page lists the segments associated with a single inventory."
+    data_note = "The dataset is derived from the cited source, and the repository does not independently evaluate or correct the original data. As a result, extracted inventories may retain source-level inconsistencies or errors."
+
     page = f"""<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{html.escape(title)}</title>
-  {SIGNWRITING_FONT_CSS}
+  <title>Inventory: {html.escape(title)}</title>
+  {PAGE_CSS}
 </head>
 <body>
-  <h1>{html.escape(title)}</h1>
+  <main class="page">
+    {render_site_nav()}
 
-  <h2>Inventory Details</h2>
-  {metadata_html}
+    <section class="content-card">
+      <h1>Inventory: {html.escape(title)}</h1>
+      {metadata_html}
+      <p class="page-description">
+        {html.escape(description)}
+        <em><strong>Data note:</strong> {html.escape(data_note)}</em>
+      </p>
+    </section>
 
-  <h2>Segments</h2>
-  {table_html}
+    <section class="content-card">
+      <h2>Segments</h2>
+      {table_html}
+    </section>
+  </main>
+  {TABLE_FILTER_SCRIPT}
 </body>
 </html>
 """
+
     out = Path(output_path)
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(page, encoding="utf-8")
@@ -203,7 +571,7 @@ def get_known_defaults(inventories_csv, segments_csv):
         and seg_name.startswith("segments") and Path(segments_csv).suffix == ".csv"
     ):
         return {
-            "output_folder": "inventories",
+            "output_folder": "docs/inventories",
             "segment_id_column": "segment_id",
             "segment_fsw_column": "fsw",
             "segment_columns_to_add": [
@@ -243,30 +611,198 @@ def collect_missing_fsws(valid_inventories, source_file_column, source_folder_co
             continue
 
         source_rows = load_csv(source_file)
-        source_fsw_column = family_configs[family]["source_fsw_column"]
+        source_segment_column = family_configs[family]["source_segment_column"]
 
         for row in source_rows:
-            fsw_value = row.get(source_fsw_column, "").strip()
-            if fsw_value and fsw_value not in segments_lookup:
-                missing_fsws.add(fsw_value)
+            segment_value = row.get(source_segment_column, "").strip()
+
+            if segment_value and segment_value not in segments_lookup:
+                missing_fsws.add(segment_value)
 
     return sorted(missing_fsws)
+
+
+def compress_number_ranges(numbers):
+    if not numbers:
+        return ""
+
+    numbers = sorted(numbers)
+    ranges = []
+    start = numbers[0]
+    previous = numbers[0]
+
+    for number in numbers[1:]:
+        if number == previous + 1:
+            previous = number
+        else:
+            if start == previous:
+                ranges.append(str(start))
+            else:
+                ranges.append(f"{start}-{previous}")
+
+            start = number
+            previous = number
+
+    if start == previous:
+        ranges.append(str(start))
+    else:
+        ranges.append(f"{start}-{previous}")
+
+    return ", ".join(ranges)
+
+
+def print_inventory_page_options(valid_inventories, source_file_column):
+    family_numbers = {}
+
+    for index, inventory in enumerate(valid_inventories, start=1):
+        source_code = inventory[source_file_column].strip()
+        family = get_source_family(source_code)
+
+        if family not in family_numbers:
+            family_numbers[family] = []
+
+        family_numbers[family].append(index)
+
+    print("\nAvailable inventory pages:")
+
+    for family, numbers in family_numbers.items():
+        print(f"- {family}: {compress_number_ranges(numbers)}")
+
+
+def parse_inventory_selection(selection, valid_inventories, source_file_column):
+    selection = selection.strip()
+
+    if selection == "" or selection.lower() == "all":
+        return valid_inventories
+
+    family_numbers = {}
+
+    for index, inventory in enumerate(valid_inventories, start=1):
+        family = get_source_family(inventory[source_file_column].strip())
+
+        if family not in family_numbers:
+            family_numbers[family] = set()
+
+        family_numbers[family].add(index)
+
+    selected_numbers = set()
+    parts = [part.strip() for part in selection.split(",") if part.strip()]
+
+    for part in parts:
+        family = part.upper()
+
+        if family in family_numbers:
+            selected_numbers.update(family_numbers[family])
+            continue
+
+        if "-" in part:
+            start_text, end_text = part.split("-", 1)
+            start = int(start_text.strip())
+            end = int(end_text.strip())
+            selected_numbers.update(range(start, end + 1))
+            continue
+
+        selected_numbers.add(int(part))
+
+    selected_inventories = []
+
+    for index, inventory in enumerate(valid_inventories, start=1):
+        if index in selected_numbers:
+            selected_inventories.append(inventory)
+
+    return selected_inventories
+
+
+def get_settings_from_defaults(segments_columns, inventories_columns, defaults):
+    print("\nDetected known CSV files.")
+    print("Press Enter to keep each default, or type a replacement value.")
+
+    output_folder = prompt_with_default(
+        "Output folder for inventory pages",
+        defaults["output_folder"],
+    )
+
+    print("\n--- segments.csv columns ---")
+    show_columns(segments_columns)
+
+    segment_id_column = prompt_column_with_default(
+        segments_columns,
+        "Segment ID column from segments.csv",
+        defaults["segment_id_column"],
+    )
+
+    segment_fsw_column = prompt_column_with_default(
+        segments_columns,
+        "FSW column from segments.csv",
+        defaults["segment_fsw_column"],
+    )
+
+    segment_columns_to_add = prompt_columns_with_default(
+        segments_columns,
+        "Columns from segments.csv to include on all inventory pages",
+        defaults["segment_columns_to_add"],
+        allow_none=True,
+    )
+
+    print("\n--- inventories.csv columns ---")
+    show_columns(inventories_columns)
+
+    source_file_column = prompt_column_with_default(
+        inventories_columns,
+        "Data source column from inventories.csv",
+        defaults["source_file_column"],
+    )
+
+    source_folder_column = prompt_column_with_default(
+        inventories_columns,
+        "Source folder column from inventories.csv",
+        defaults["source_folder_column"],
+    )
+
+    inventory_id_column = prompt_column_with_default(
+        inventories_columns,
+        "Inventory ID column from inventories.csv",
+        defaults["inventory_id_column"],
+    )
+
+    inventory_title_column = prompt_column_with_default(
+        inventories_columns,
+        "Inventory name column from inventories.csv",
+        defaults["inventory_title_column"],
+    )
+
+    return {
+        "output_folder": output_folder,
+        "segment_id_column": segment_id_column,
+        "segment_fsw_column": segment_fsw_column,
+        "segment_columns_to_add": segment_columns_to_add,
+        "source_file_column": source_file_column,
+        "source_folder_column": source_folder_column,
+        "inventory_id_column": inventory_id_column,
+        "inventory_title_column": inventory_title_column,
+    }
+
+
+def choose_known_csv_paths():
+    inventories_csv = prompt_with_default(
+        "Inventories CSV path",
+        "data/slphoible/inventories.csv",
+    )
+
+    segments_csv = prompt_with_default(
+        "Segments CSV path",
+        "data/slphoible/segments.csv",
+    )
+
+    return inventories_csv, segments_csv
 
 
 def main():
     print()
     print("This program creates individual inventory HTML pages from inventories.csv.")
-    print("It displays the inventory details, reads the FSW values from each inventory source file, and uses segments.csv to show the corresponding standardized segment information.")
+    print("It displays the inventory details, reads segment values from each inventory source file, and uses segments.csv to show the corresponding standardized segment information.")
 
-    inventories_csv = input(
-        "\nEnter the path to the inventories CSV "
-        "(for example: data/slphoible/inventories.csv): "
-    ).strip()
-
-    segments_csv = input(
-        "Enter the path to the segments CSV "
-        "(for example: data/slphoible/segments.csv): "
-    ).strip()
+    inventories_csv, segments_csv = choose_known_csv_paths()
 
     inventories_rows = load_csv(inventories_csv)
     segments_rows = load_csv(segments_csv)
@@ -274,6 +810,7 @@ def main():
     if not inventories_rows:
         print("Inventories CSV is empty.")
         return
+
     if not segments_rows:
         print("Segments CSV is empty.")
         return
@@ -283,80 +820,25 @@ def main():
 
     defaults = get_known_defaults(inventories_csv, segments_csv)
 
-    if defaults:
-        print("\nDetected known CSV files.")
-        print(f"Suggested output folder: {defaults['output_folder']}")
+    if not defaults:
+        print("\nNo defaults found for the selected CSV files.")
+        print("Add these CSV files to get_known_defaults() before generating inventory pages.")
+        return
 
-        print("\nFrom segments.csv:")
-        print(f"  Segment ID column: {defaults['segment_id_column']}")
-        print(f"  FSW column: {defaults['segment_fsw_column']}")
-        print("  Segment columns to add: " + ", ".join(defaults["segment_columns_to_add"]))
+    settings = get_settings_from_defaults(
+        segments_columns=segments_columns,
+        inventories_columns=inventories_columns,
+        defaults=defaults,
+    )
 
-        print("\nFrom inventories.csv:")
-        print(f"  Data source column: {defaults['source_file_column']}")
-        print(f"  Data source location column: {defaults['source_folder_column']}")
-        print(f"  Inventory ID column: {defaults['inventory_id_column']}")
-        print(f"  Inventory name column: {defaults['inventory_title_column']}")
-
-        use_defaults = input("\nUse these defaults? (y/n): ").strip().lower()
-
-        if use_defaults == "y":
-            output_folder = defaults["output_folder"]
-            segment_id_column = defaults["segment_id_column"]
-            segment_fsw_column = defaults["segment_fsw_column"]
-            segment_columns_to_add = defaults["segment_columns_to_add"]
-            source_file_column = defaults["source_file_column"]
-            source_folder_column = defaults["source_folder_column"]
-            inventory_id_column = defaults["inventory_id_column"]
-            inventory_title_column = defaults["inventory_title_column"]
-        else:
-            output_folder = input(
-                "\nEnter the output folder for the inventory pages "
-                "(for example: inventories): "
-            ).strip()
-
-            print("\n--- segments.csv columns ---")
-            show_columns(segments_columns)
-            segment_id_column = choose_one_column(segments_columns, "Select the segment ID column from segments.csv")
-            segment_fsw_column = choose_one_column(segments_columns, "Select the FSW column from segments.csv")
-            segment_columns_to_add = choose_columns(
-                segments_columns,
-                "Select the columns from segments.csv to include on all inventory pages",
-                allow_none=True,
-            )
-
-            print("\n--- inventories.csv columns ---")
-            show_columns(inventories_columns)
-            source_file_column = choose_one_column(inventories_columns, "Select the data source column from inventories.csv")
-            source_folder_column = choose_one_column(inventories_columns, "Select the source folder column from inventories.csv")
-            inventory_id_column = choose_one_column(inventories_columns, "Select the inventory ID column from inventories.csv")
-            inventory_title_column = choose_one_column(inventories_columns, "Select the inventory name column from inventories.csv")
-    else:
-        output_folder = input(
-            "\nEnter the output folder for the inventory pages "
-            "(for example: inventories): "
-        ).strip()
-
-        print("\n--- segments.csv columns ---")
-        show_columns(segments_columns)
-        segment_id_column = choose_one_column(segments_columns, "Select the segment ID column from segments.csv")
-        segment_fsw_column = choose_one_column(segments_columns, "Select the FSW column from segments.csv")
-        segment_columns_to_add = choose_columns(
-            segments_columns,
-            "Select the columns from segments.csv to include on all inventory pages",
-            allow_none=True,
-        )
-
-        print("\n--- inventories.csv columns ---")
-        show_columns(inventories_columns)
-        source_file_column = choose_one_column(inventories_columns, "Select the data source column from inventories.csv")
-        source_folder_column = choose_one_column(inventories_columns, "Select the source folder column from inventories.csv")
-        inventory_id_column = choose_one_column(inventories_columns, "Select the inventory ID column from inventories.csv")
-        inventory_title_column = choose_one_column(inventories_columns, "Select the inventory name column from inventories.csv")
-
-    page_count_input = input(
-        "\nHow many inventory pages do you want to generate? Enter a number or 'all': "
-    ).strip().lower()
+    segment_id_column = settings["segment_id_column"]
+    segment_fsw_column = settings["segment_fsw_column"]
+    segment_columns_to_add = settings["segment_columns_to_add"]
+    source_file_column = settings["source_file_column"]
+    source_folder_column = settings["source_folder_column"]
+    inventory_id_column = settings["inventory_id_column"]
+    inventory_title_column = settings["inventory_title_column"]
+    output_folder = settings["output_folder"]
 
     if segment_id_column in segment_columns_to_add:
         segment_columns_to_add = [
@@ -373,9 +855,24 @@ def main():
         print("No valid inventory rows found.")
         return
 
-    if page_count_input != "all":
-        page_count = int(page_count_input)
-        valid_inventories = valid_inventories[:page_count]
+    print_inventory_page_options(
+        valid_inventories=valid_inventories,
+        source_file_column=source_file_column,
+    )
+
+    inventory_selection = input(
+        "\nWhich inventory pages do you want to generate? Enter numbers, ranges, family codes, or 'all' (for example: 1, 3, 7-12, SP, or all): "
+    ).strip()
+
+    valid_inventories = parse_inventory_selection(
+        selection=inventory_selection,
+        valid_inventories=valid_inventories,
+        source_file_column=source_file_column,
+    )
+
+    if not valid_inventories:
+        print("No inventory pages selected.")
+        return
 
     family_configs = {}
 
@@ -396,6 +893,7 @@ def main():
             continue
 
         sample_rows = load_csv(sample_file)
+
         if not sample_rows:
             print(f"Skipping source family {family}: sample file is empty.")
             continue
@@ -405,13 +903,19 @@ def main():
         print(f"\n--- Source family: {family} ---")
         show_columns(source_columns)
 
-        source_fsw_column = choose_one_column(
+        default_source_segment_column = get_default_source_segment_column(
+            family,
             source_columns,
-            f"Select the FSW column for all {family} source files",
+        )
+
+        source_segment_column = prompt_column_with_default(
+            source_columns,
+            f"Source column containing segment values for all {family} source files",
+            default_source_segment_column,
         )
 
         family_configs[family] = {
-            "source_fsw_column": source_fsw_column,
+            "source_segment_column": source_segment_column,
         }
 
     segments_lookup = build_segments_lookup(
@@ -429,10 +933,12 @@ def main():
     )
 
     if missing_fsws:
-        print("\nThe following FSW values were found in inventory source files but not in segments.csv:")
+        print("\nThe following segment values were found in inventory source files but not in segments.csv:")
+
         for fsw in missing_fsws:
             print(f"  - {fsw}")
-        print("\nPlease update segments.csv with these FSW values before generating inventory pages.")
+
+        print("\nPlease update segments.csv with these values before generating inventory pages.")
         print("Cancelled.")
         return
 
@@ -458,16 +964,16 @@ def main():
         source_rows = load_csv(source_file)
 
         config = family_configs[family]
-        source_fsw_column = config["source_fsw_column"]
+        source_segment_column = config["source_segment_column"]
 
         source_rows = [
             row for row in source_rows
-            if row.get(source_fsw_column, "").strip() != ""
+            if row.get(source_segment_column, "").strip() != ""
         ]
 
         joined_rows = join_inventory_rows(
             source_rows,
-            source_fsw_column=source_fsw_column,
+            source_segment_column=source_segment_column,
             segments_lookup=segments_lookup,
             segment_columns_to_add=segment_columns_to_add,
         )

--- a/scripts/pages/lbuilder.py
+++ b/scripts/pages/lbuilder.py
@@ -1,8 +1,222 @@
 import csv
+import html
 import sys
 from pathlib import Path
 
 csv.field_size_limit(sys.maxsize)
+
+PAGE_CSS = """
+<style>
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.language-title {
+  line-height: 1.2;
+  max-width: 1200px;
+}
+
+.title-extra {
+  color: #888;
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-language-id,
+.col-language-abbreviation,
+.col-glottocode,
+.col-iso-639-3,
+.col-macro-area,
+.col-segments,
+.col-handshapes {
+  white-space: nowrap;
+}
+
+.col-inventory,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.empty-cell {
+  color: #aaa;
+}
+</style>
+"""
+
+TABLE_FILTER_SCRIPT = """
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
+"""
 
 
 def load_csv(csv_path):
@@ -12,62 +226,149 @@ def load_csv(csv_path):
 
 def show_columns(columns):
     print("\nAvailable columns:")
+
     for i, col in enumerate(columns, start=1):
         print(f"{i}. {col}")
 
 
-def choose_one_column(columns, prompt):
-    print(f"\n{prompt}")
-    raw = input("> ").strip()
-    return columns[int(raw) - 1]
+def format_columns_with_numbers(columns, selected_columns):
+    formatted_columns = []
+
+    for selected_column in selected_columns:
+        column_number = columns.index(selected_column) + 1
+        formatted_columns.append(f"{column_number}. {selected_column}")
+
+    return ", ".join(formatted_columns)
 
 
-def choose_columns(columns, prompt):
-    print(f"\n{prompt}")
-    raw = input("> ").strip()
+def format_column_with_number(columns, selected_column):
+    column_number = columns.index(selected_column) + 1
+    return f"{column_number}. {selected_column}"
+
+
+def prompt_with_default(label, default_value):
+    value = input(
+        f"\n{label} [{default_value}] (Enter = default): "
+    ).strip()
+
+    if value == "":
+        return default_value
+
+    return value
+
+
+def prompt_columns_with_default(columns, label, default_columns):
+    default_text = format_columns_with_numbers(columns, default_columns)
+
+    raw = input(
+        f"\n{label} [{default_text}] (Enter = default, or type numbers): "
+    ).strip()
+
+    if raw == "":
+        return default_columns
+
     indices = [int(x.strip()) - 1 for x in raw.split(",")]
     return [columns[i] for i in indices]
+
+
+def prompt_column_with_default(columns, label, default_column):
+    default_text = format_column_with_number(columns, default_column)
+
+    raw = input(
+        f"\n{label} [{default_text}] (Enter = default, or type number): "
+    ).strip()
+
+    if raw == "":
+        return default_column
+
+    return columns[int(raw) - 1]
 
 
 def parse_selection(selection, max_index):
     selection = selection.strip().lower()
 
+    if selection == "" or selection == "all":
+        return list(range(max_index))
+
     if selection == "0":
         return []
-    if selection == "all":
-        return list(range(max_index))
 
     chosen = set()
 
     for part in selection.split(","):
         part = part.strip()
+
         if "-" in part:
             start, end = part.split("-", 1)
             start_i = int(start) - 1
             end_i = int(end) - 1
+
             for i in range(start_i, end_i + 1):
                 if 0 <= i < max_index:
                     chosen.add(i)
         else:
             i = int(part) - 1
+
             if 0 <= i < max_index:
                 chosen.add(i)
 
     return sorted(chosen)
 
 
-def html_escape(value):
+def split_parenthetical_name(name):
+    name = name.strip()
+
+    if "(" not in name or not name.endswith(")"):
+        return name, ""
+
+    main_name, parenthetical = name.split("(", 1)
+    return main_name.strip(), parenthetical.strip(")")
+
+
+def render_language_title(title):
+    main_name, components = split_parenthetical_name(title)
+
+    if components:
+        return (
+            '<h1 class="language-title">'
+            f'Language: {html.escape(main_name)} '
+            f'<span class="title-extra">({html.escape(components)})</span>'
+            '</h1>'
+        )
+
     return (
-        str(value)
-        .replace("&", "&amp;")
-        .replace("<", "&lt;")
-        .replace(">", "&gt;")
-        .replace('"', "&quot;")
+        '<h1 class="language-title">'
+        f'Language: {html.escape(main_name)}'
+        '</h1>'
     )
 
 
 def format_header(column_name):
-    return column_name.replace("_", " ").title()
+    special_headers = {
+        "ISO-639-3": "ISO 639-3",
+    }
+
+    if column_name in special_headers:
+        return special_headers[column_name]
+
+    return html.escape(column_name.replace("_", " ").title())
+
+
+def format_cell_value(column_name, value):
+    value = str(value).strip()
+
+    if value == "":
+        return '<span class="empty-cell">—</span>'
+
+    if column_name in ["glottocode", "ISO-639-3"] and "," in value:
+        values = [html.escape(part.strip()) for part in value.split(",")]
+        return "<br>".join(values)
+
+    return html.escape(value)
+
+
+def column_class_name(column_name):
+    return f"col-{column_name.replace('_', '-').lower()}"
 
 
 def build_source_label(inventory_row, contributor_column, year_column):
@@ -76,25 +377,56 @@ def build_source_label(inventory_row, contributor_column, year_column):
 
     if contributor and year:
         return f"{contributor} ({year})"
+
     if contributor:
         return contributor
+
     if year:
         return year
+
     return ""
+
+
+def render_search_box():
+    return (
+        '<input id="table-search" class="table-search" type="search" '
+        'placeholder="Type to filter rows...">'
+    )
+
+
+def render_site_nav():
+    return """
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
+"""
 
 
 def render_language_details(language_row, columns_to_show):
     parts = []
-    parts.append("<table border='1' cellspacing='0' cellpadding='6'>")
-    parts.append("<tbody>")
+    parts.append('<div class="metadata-table-container">')
+    parts.append('<table class="metadata-table">')
+    parts.append("<thead><tr>")
 
     for col in columns_to_show:
-        parts.append("<tr>")
-        parts.append(f"<th>{html_escape(format_header(col))}</th>")
-        parts.append(f"<td>{html_escape(language_row.get(col, ''))}</td>")
-        parts.append("</tr>")
+        column_class = column_class_name(col)
+        parts.append(f'<th class="{column_class}">{format_header(col)}</th>')
 
-    parts.append("</tbody></table>")
+    parts.append("</tr></thead>")
+    parts.append("<tbody><tr>")
+
+    for col in columns_to_show:
+        value = language_row.get(col, "")
+        column_class = column_class_name(col)
+        parts.append(f'<td class="{column_class}">{format_cell_value(col, value)}</td>')
+
+    parts.append("</tr></tbody>")
+    parts.append("</table>")
+    parts.append("</div>")
+
     return "\n".join(parts)
 
 
@@ -104,55 +436,76 @@ def render_inventory_table(
     inventory_name_column,
     source_label_column,
     ct_segments_column,
+    ct_handshapes_column,
 ):
     if not matching_inventories:
-        return ""
+        return "<p>No inventories found for this language.</p>"
 
     parts = []
-    parts.append("<table border='1' cellspacing='0' cellpadding='6'>")
+    parts.append(render_search_box())
+    parts.append('<div class="table-container">')
+    parts.append('<table class="filterable-table">')
     parts.append("<thead><tr>")
-    parts.append("<th>Inventory</th>")
-    parts.append("<th>Source</th>")
-    parts.append("<th>Segments</th>")
+    parts.append('<th class="col-inventory">Inventory</th>')
+    parts.append('<th class="col-source">Source</th>')
+    parts.append('<th class="col-segments">Segments<br><span>Total</span></th>')
+    parts.append('<th class="col-handshapes">Handshapes<br><span>Count</span></th>')
     parts.append("</tr></thead>")
     parts.append("<tbody>")
 
     for row in matching_inventories:
-        inv_id = row.get(inventory_id_column, "")
-        inv_name = row.get(inventory_name_column, "")
-        source = row.get(source_label_column, "")
-        segments = row.get(ct_segments_column, "")
+        inv_id = row.get(inventory_id_column, "").strip()
+        inv_name = row.get(inventory_name_column, "").strip()
+        source = row.get(source_label_column, "").strip()
+        segments = row.get(ct_segments_column, "").strip()
+        handshapes = row.get(ct_handshapes_column, "").strip()
+
         link = f"../inventories/{inv_id}.html"
 
         parts.append("<tr>")
-        parts.append(f'<td><a href="{html_escape(link)}">{html_escape(inv_name)}</a></td>')
-        parts.append(f"<td>{html_escape(source)}</td>")
-        parts.append(f"<td>{html_escape(segments)}</td>")
+        parts.append(f'<td class="col-inventory"><a href="{html.escape(link)}">{format_cell_value("inventory", inv_name)}</a></td>')
+        parts.append(f'<td class="col-source">{format_cell_value("source", source)}</td>')
+        parts.append(f'<td class="col-segments">{format_cell_value("segments", segments)}</td>')
+        parts.append(f'<td class="col-handshapes">{format_cell_value("handshapes", handshapes)}</td>')
         parts.append("</tr>")
 
     parts.append("</tbody></table>")
+    parts.append("</div>")
+
     return "\n".join(parts)
 
 
 def write_language_page(output_path, title, details_html, inventory_section_html):
+    description = "This page lists all the inventories associated with the specified sign language(s)."
+
     page = f"""<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{html_escape(title)}</title>
+  <title>Language: {html.escape(title)}</title>
+  {PAGE_CSS}
 </head>
 <body>
-  <h1>{html_escape(title)}</h1>
+  <main class="page">
+    {render_site_nav()}
 
-  <h2>Language Details</h2>
-  {details_html}
+    <section class="content-card">
+      {render_language_title(title)}
+      {details_html}
+      <p class="page-description">{html.escape(description)}</p>
+    </section>
 
-  <h2>Inventories</h2>
-  {inventory_section_html}
+    <section class="content-card">
+      <h2>Inventories</h2>
+      {inventory_section_html}
+    </section>
+  </main>
+  {TABLE_FILTER_SCRIPT}
 </body>
 </html>
 """
+
     out = Path(output_path)
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(page, encoding="utf-8")
@@ -164,12 +517,11 @@ def get_known_defaults(languages_csv, inventories_csv):
 
     if lang_norm.endswith("languages.csv") and inv_norm.endswith("inventories.csv"):
         return {
-            "output_folder": "languages",
+            "output_folder": "docs/languages",
             "language_id_column": "language_id",
             "language_name_column": "language_name",
             "language_detail_columns": [
                 "language_id",
-                "language_name",
                 "language_abbreviation",
                 "glottocode",
                 "ISO-639-3",
@@ -181,6 +533,7 @@ def get_known_defaults(languages_csv, inventories_csv):
             "contributor_column": "contributor",
             "year_column": "year",
             "ct_segments_column": "ct_segments",
+            "ct_handshapes_column": "ct_handshapes",
         }
 
     return None
@@ -191,6 +544,7 @@ def print_discrepancy_report(languages_only, inventories_only):
 
     if languages_only:
         print("\nIn languages.csv but not found in inventories.csv:")
+
         for name in languages_only:
             print(f"  - {name}")
     else:
@@ -198,10 +552,115 @@ def print_discrepancy_report(languages_only, inventories_only):
 
     if inventories_only:
         print("\nIn inventories.csv but not found in languages.csv:")
+
         for name in inventories_only:
             print(f"  - {name}")
     else:
         print("\nAll inventory language names were found in languages.csv.")
+
+
+def get_settings_from_defaults(language_columns, inventory_columns, defaults):
+    print("\nDetected known CSV files.")
+    print("Press Enter to keep each default, or type a replacement value.")
+
+    output_folder = prompt_with_default(
+        "Output folder for language pages",
+        defaults["output_folder"],
+    )
+
+    print("\n--- languages.csv columns ---")
+    show_columns(language_columns)
+
+    language_id_column = prompt_column_with_default(
+        language_columns,
+        "Language ID column from languages.csv",
+        defaults["language_id_column"],
+    )
+
+    language_name_column = prompt_column_with_default(
+        language_columns,
+        "Language name column from languages.csv",
+        defaults["language_name_column"],
+    )
+
+    language_detail_columns = prompt_columns_with_default(
+        language_columns,
+        "Columns to show in the language details table",
+        defaults["language_detail_columns"],
+    )
+
+    print("\n--- inventories.csv columns ---")
+    show_columns(inventory_columns)
+
+    inventory_id_column = prompt_column_with_default(
+        inventory_columns,
+        "Inventory ID column from inventories.csv",
+        defaults["inventory_id_column"],
+    )
+
+    inventory_name_column = prompt_column_with_default(
+        inventory_columns,
+        "Inventory name column from inventories.csv",
+        defaults["inventory_name_column"],
+    )
+
+    inventory_language_name_column = prompt_column_with_default(
+        inventory_columns,
+        "Language name column from inventories.csv used for matching",
+        defaults["inventory_language_name_column"],
+    )
+
+    contributor_column = prompt_column_with_default(
+        inventory_columns,
+        "Contributor column from inventories.csv",
+        defaults["contributor_column"],
+    )
+
+    year_column = prompt_column_with_default(
+        inventory_columns,
+        "Year column from inventories.csv",
+        defaults["year_column"],
+    )
+
+    ct_segments_column = prompt_column_with_default(
+        inventory_columns,
+        "Total segments column from inventories.csv",
+        defaults["ct_segments_column"],
+    )
+
+    ct_handshapes_column = prompt_column_with_default(
+        inventory_columns,
+        "Handshape count column from inventories.csv",
+        defaults["ct_handshapes_column"],
+    )
+
+    return {
+        "output_folder": output_folder,
+        "language_id_column": language_id_column,
+        "language_name_column": language_name_column,
+        "language_detail_columns": language_detail_columns,
+        "inventory_id_column": inventory_id_column,
+        "inventory_name_column": inventory_name_column,
+        "inventory_language_name_column": inventory_language_name_column,
+        "contributor_column": contributor_column,
+        "year_column": year_column,
+        "ct_segments_column": ct_segments_column,
+        "ct_handshapes_column": ct_handshapes_column,
+    }
+
+
+def choose_known_csv_paths():
+    languages_csv = prompt_with_default(
+        "Languages CSV path",
+        "data/slphoible/languages.csv",
+    )
+
+    inventories_csv = prompt_with_default(
+        "Inventories CSV path",
+        "data/slphoible/inventories.csv",
+    )
+
+    return languages_csv, inventories_csv
 
 
 def main():
@@ -209,15 +668,7 @@ def main():
     print("This program creates individual language HTML pages from languages.csv.")
     print("Each language page shows the language details and the inventories that match that language.")
 
-    languages_csv = input(
-        "\nEnter the path to the languages CSV "
-        "(for example: data/slphoible/languages.csv): "
-    ).strip()
-
-    inventories_csv = input(
-        "Enter the path to the inventories CSV "
-        "(for example: data/slphoible/inventories.csv): "
-    ).strip()
+    languages_csv, inventories_csv = choose_known_csv_paths()
 
     languages_rows = load_csv(languages_csv)
     inventories_rows = load_csv(inventories_csv)
@@ -225,6 +676,7 @@ def main():
     if not languages_rows:
         print("Languages CSV is empty.")
         return
+
     if not inventories_rows:
         print("Inventories CSV is empty.")
         return
@@ -234,88 +686,28 @@ def main():
 
     defaults = get_known_defaults(languages_csv, inventories_csv)
 
-    if defaults:
-        print("\nDetected known CSV files.")
-        print(f"Suggested output folder: {defaults['output_folder']}")
+    if not defaults:
+        print("\nNo defaults found for the selected CSV files.")
+        print("Add these CSV files to get_known_defaults() before generating language pages.")
+        return
 
-        print("\nFrom languages.csv:")
-        print(f"  Language ID column: {defaults['language_id_column']}")
-        print(f"  Language name column: {defaults['language_name_column']}")
-        print("  Language detail columns: " + ", ".join(defaults["language_detail_columns"]))
+    settings = get_settings_from_defaults(
+        language_columns=language_columns,
+        inventory_columns=inventory_columns,
+        defaults=defaults,
+    )
 
-        print("\nFrom inventories.csv:")
-        print(f"  Inventory ID column: {defaults['inventory_id_column']}")
-        print(f"  Inventory name column: {defaults['inventory_name_column']}")
-        print(f"  Inventory language name column: {defaults['inventory_language_name_column']}")
-        print(f"  Contributor column: {defaults['contributor_column']}")
-        print(f"  Year column: {defaults['year_column']}")
-        print(f"  Count of segments column: {defaults['ct_segments_column']}")
-
-        use_defaults = input("\nUse these defaults? (y/n): ").strip().lower()
-
-        if use_defaults == "y":
-            output_folder = defaults["output_folder"]
-            language_id_column = defaults["language_id_column"]
-            language_name_column = defaults["language_name_column"]
-            language_detail_columns = defaults["language_detail_columns"]
-            inventory_id_column = defaults["inventory_id_column"]
-            inventory_name_column = defaults["inventory_name_column"]
-            inventory_language_name_column = defaults["inventory_language_name_column"]
-            contributor_column = defaults["contributor_column"]
-            year_column = defaults["year_column"]
-            ct_segments_column = defaults["ct_segments_column"]
-        else:
-            output_folder = input(
-                "\nEnter the output folder for the language pages "
-                "(for example: languages): "
-            ).strip()
-
-            print("\n--- languages.csv columns ---")
-            show_columns(language_columns)
-            language_id_column = choose_one_column(language_columns, "Select the language ID column from languages.csv")
-            language_name_column = choose_one_column(language_columns, "Select the language name column from languages.csv")
-            language_detail_columns = choose_columns(
-                language_columns,
-                "Enter the column numbers to show in the language details table, separated by commas:"
-            )
-
-            print("\n--- inventories.csv columns ---")
-            show_columns(inventory_columns)
-            inventory_id_column = choose_one_column(inventory_columns, "Select the inventory ID column from inventories.csv")
-            inventory_name_column = choose_one_column(inventory_columns, "Select the inventory name column from inventories.csv")
-            inventory_language_name_column = choose_one_column(
-                inventory_columns,
-                "Select the language name column from inventories.csv (used for matching):"
-            )
-            contributor_column = choose_one_column(inventory_columns, "Select the contributor column from inventories.csv")
-            year_column = choose_one_column(inventory_columns, "Select the year column from inventories.csv")
-            ct_segments_column = choose_one_column(inventory_columns, "Select the count of segments column from inventories.csv")
-    else:
-        output_folder = input(
-            "\nEnter the output folder for the language pages "
-            "(for example: languages): "
-        ).strip()
-
-        print("\n--- languages.csv columns ---")
-        show_columns(language_columns)
-        language_id_column = choose_one_column(language_columns, "Select the language ID column from languages.csv")
-        language_name_column = choose_one_column(language_columns, "Select the language name column from languages.csv")
-        language_detail_columns = choose_columns(
-            language_columns,
-            "Enter the column numbers to show in the language details table, separated by commas:"
-        )
-
-        print("\n--- inventories.csv columns ---")
-        show_columns(inventory_columns)
-        inventory_id_column = choose_one_column(inventory_columns, "Select the inventory ID column from inventories.csv")
-        inventory_name_column = choose_one_column(inventory_columns, "Select the inventory name column from inventories.csv")
-        inventory_language_name_column = choose_one_column(
-            inventory_columns,
-            "Select the language name column from inventories.csv (used for matching):"
-        )
-        contributor_column = choose_one_column(inventory_columns, "Select the contributor column from inventories.csv")
-        year_column = choose_one_column(inventory_columns, "Select the year column from inventories.csv")
-        ct_segments_column = choose_one_column(inventory_columns, "Select the count of segments column from inventories.csv")
+    output_folder = settings["output_folder"]
+    language_id_column = settings["language_id_column"]
+    language_name_column = settings["language_name_column"]
+    language_detail_columns = settings["language_detail_columns"]
+    inventory_id_column = settings["inventory_id_column"]
+    inventory_name_column = settings["inventory_name_column"]
+    inventory_language_name_column = settings["inventory_language_name_column"]
+    contributor_column = settings["contributor_column"]
+    year_column = settings["year_column"]
+    ct_segments_column = settings["ct_segments_column"]
+    ct_handshapes_column = settings["ct_handshapes_column"]
 
     valid_languages = [
         row for row in languages_rows
@@ -330,12 +722,15 @@ def main():
     if not valid_languages:
         print("No valid language rows found.")
         return
+
     if not valid_inventories:
         print("No valid inventory rows found.")
         return
 
+    source_label_column = "_source_label_temp"
+
     for inv in valid_inventories:
-        inv["_source_label_temp"] = build_source_label(inv, contributor_column, year_column)
+        inv[source_label_column] = build_source_label(inv, contributor_column, year_column)
 
     language_names = {
         row.get(language_name_column, "").strip()
@@ -354,15 +749,17 @@ def main():
 
     print_discrepancy_report(languages_only, inventories_only)
 
-    continue_anyway = input(
-        "\nContinue with exact language-name matching anyway? (y/n): "
-    ).strip().lower()
+    if languages_only or inventories_only:
+        continue_anyway = input(
+            "\nContinue with exact language-name matching anyway? (y/n): "
+        ).strip().lower()
 
-    if continue_anyway != "y":
-        print("Cancelled.")
-        return
+        if continue_anyway != "y":
+            print("Cancelled.")
+            return
 
     print("\n--- Valid languages ---")
+
     for i, row in enumerate(valid_languages, start=1):
         print(f"{i}. {row.get(language_id_column, '')} | {row.get(language_name_column, '')}")
 
@@ -371,8 +768,8 @@ def main():
     print("  0   = none")
     print("  1-5 = range")
     print("  1,4,7 = specific entries")
-    selection = input("> ").strip().lower()
 
+    selection = input("> ").strip().lower()
     chosen_indexes = parse_selection(selection, len(valid_languages))
     selected_languages = [valid_languages[i] for i in chosen_indexes]
 
@@ -398,15 +795,15 @@ def main():
                 matching_inventories,
                 inventory_id_column=inventory_id_column,
                 inventory_name_column=inventory_name_column,
-                source_label_column="_source_label_temp",
+                source_label_column=source_label_column,
                 ct_segments_column=ct_segments_column,
+                ct_handshapes_column=ct_handshapes_column,
             )
         else:
-            inventory_section_html = f"<p>No inventories found for {html_escape(language_name)}.</p>"
+            inventory_section_html = f"<p>No inventories found for {html.escape(language_name)}.</p>"
 
-        title = f"{language_name}"
         output_path = Path(output_folder) / f"{language_id}.html"
-        write_language_page(output_path, title, details_html, inventory_section_html)
+        write_language_page(output_path, language_name, details_html, inventory_section_html)
         generated += 1
 
     print(f"\nCreated {generated} language page(s) in: {output_folder}")

--- a/scripts/pages/sbuilder.py
+++ b/scripts/pages/sbuilder.py
@@ -1,10 +1,11 @@
 import csv
+import html
 import sys
 from pathlib import Path
 
 csv.field_size_limit(sys.maxsize)
 
-SIGNWRITING_FONT_CSS = """
+PAGE_CSS = """
 <style>
 @font-face {
   font-family: "SuttonSignWritingLine";
@@ -12,23 +13,234 @@ SIGNWRITING_FONT_CSS = """
     local('SuttonSignWritingLine'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingLine.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingFill";
   src:
     local('SuttonSignWritingFill'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingFill.ttf') format('truetype');
 }
+
 @font-face {
   font-family: "SuttonSignWritingOneD";
   src:
     local('SuttonSignWritingOneD'),
     url('https://unpkg.com/@sutton-signwriting/font-ttf@1.0.0/font/SuttonSignWritingOneD.ttf') format('truetype');
 }
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 0;
+  background-color: #f8f9fb;
+  color: #222;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.site-nav a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background-color: white;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+}
+
+h1,
+h2 {
+  margin-top: 0;
+  font-size: 1.5rem;
+}
+
+.page-description {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.content-card .page-description {
+  margin-bottom: 0;
+}
+
+.content-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.content-card:first-of-type {
+  margin-top: 0;
+}
+
+.table-search {
+  width: 100%;
+  max-width: 420px;
+  box-sizing: border-box;
+  margin-bottom: 1rem;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  font: inherit;
+  background-color: white;
+}
+
+.table-search:focus {
+  outline: 2px solid #c7d2fe;
+  border-color: #6b7280;
+}
+
+.table-container {
+  max-height: 70vh;
+  overflow: auto;
+  border-radius: 12px;
+  background-color: white;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.metadata-table-container {
+  overflow-x: auto;
+  border-radius: 12px;
+  background-color: white;
+}
+
+table {
+  width: 100%;
+  min-width: 100%;
+  border-collapse: collapse;
+  background-color: white;
+}
+
+thead {
+  background-color: #eef1f5;
+}
+
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: #eef1f5;
+}
+
+th,
+td {
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  vertical-align: top;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #333;
+}
+
+th span {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+td {
+  vertical-align: middle;
+  font-size: 0.95rem;
+}
+
+.metadata-table th {
+  background-color: #eef1f5;
+}
+
+.col-segment-id,
+.col-segment-class,
+.col-fsw,
+.col-signwriting-1,
+.col-signwriting-2 {
+  white-space: nowrap;
+}
+
+.col-hamnosys-1-initial-configuration,
+.col-hamnosys-2-basic-handshape,
+.col-hamnosys-3-handshape-modifications {
+  white-space: normal;
+  min-width: 180px;
+  max-width: 320px;
+  overflow-wrap: break-word;
+}
+
+.col-inventory,
+.col-language,
+.col-source {
+  white-space: normal;
+  max-width: 420px;
+  overflow-wrap: break-word;
+}
+
+tbody tr:hover {
+  background-color: #f4f7fb;
+}
+
+a {
+  color: #5b2ea6;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
 .signwriting {
   font-family: "SuttonSignWritingOneD", "SuttonSignWritingLine", "SuttonSignWritingFill";
-  font-size: 2em;
+  font-size: 1.8em;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.empty-cell {
+  color: #aaa;
 }
 </style>
+"""
+
+TABLE_FILTER_SCRIPT = """
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("table-search");
+  const tableRows = document.querySelectorAll(".filterable-table tbody tr");
+
+  if (!searchInput) {
+    return;
+  }
+
+  searchInput.addEventListener("input", function () {
+    const query = searchInput.value.toLowerCase();
+
+    tableRows.forEach(function (row) {
+      const rowText = row.textContent.toLowerCase();
+
+      if (rowText.includes(query)) {
+        row.style.display = "";
+      } else {
+        row.style.display = "none";
+      }
+    });
+  });
+});
+</script>
 """
 
 
@@ -39,55 +251,132 @@ def load_csv(csv_path):
 
 def show_columns(columns):
     print("\nAvailable columns:")
+
     for i, col in enumerate(columns, start=1):
         print(f"{i}. {col}")
 
 
-def choose_one_column(columns, prompt):
-    print(f"\n{prompt}")
-    raw = input("> ").strip()
-    return columns[int(raw) - 1]
+def format_columns_with_numbers(columns, selected_columns):
+    formatted_columns = []
+
+    for selected_column in selected_columns:
+        column_number = columns.index(selected_column) + 1
+        formatted_columns.append(f"{column_number}. {selected_column}")
+
+    return ", ".join(formatted_columns)
 
 
-def choose_columns(columns, prompt):
-    print(f"\n{prompt}")
-    raw = input("> ").strip()
+def format_column_with_number(columns, selected_column):
+    column_number = columns.index(selected_column) + 1
+    return f"{column_number}. {selected_column}"
+
+
+def prompt_with_default(label, default_value):
+    value = input(
+        f"\n{label} [{default_value}] (Enter = default): "
+    ).strip()
+
+    if value == "":
+        return default_value
+
+    return value
+
+
+def prompt_columns_with_default(columns, label, default_columns):
+    default_text = format_columns_with_numbers(columns, default_columns)
+
+    raw = input(
+        f"\n{label} [{default_text}] (Enter = default, or type numbers): "
+    ).strip()
+
+    if raw == "":
+        return default_columns
+
     indices = [int(x.strip()) - 1 for x in raw.split(",")]
     return [columns[i] for i in indices]
+
+
+def prompt_column_with_default(columns, label, default_column):
+    default_text = format_column_with_number(columns, default_column)
+
+    raw = input(
+        f"\n{label} [{default_text}] (Enter = default, or type number): "
+    ).strip()
+
+    if raw == "":
+        return default_column
+
+    return columns[int(raw) - 1]
 
 
 def parse_selection(selection, max_index):
     selection = selection.strip().lower()
 
+    if selection == "" or selection == "all":
+        return list(range(max_index))
+
     if selection == "0":
         return []
-    if selection == "all":
-        return list(range(max_index))
 
     chosen = set()
 
     for part in selection.split(","):
         part = part.strip()
+
         if "-" in part:
             start, end = part.split("-", 1)
             start_i = int(start) - 1
             end_i = int(end) - 1
+
             for i in range(start_i, end_i + 1):
                 if 0 <= i < max_index:
                     chosen.add(i)
         else:
             i = int(part) - 1
+
             if 0 <= i < max_index:
                 chosen.add(i)
 
     return sorted(chosen)
 
 
+def find_column_case_insensitive(columns, target_name):
+    for column in columns:
+        if column.lower() == target_name.lower():
+            return column
+
+    return None
+
+
+def get_default_source_segment_column(family, source_columns):
+    family_defaults = {
+        "LQ": "FSW",
+        "SP": "Handshape",
+    }
+
+    default_column = family_defaults.get(family)
+
+    if default_column:
+        matched_column = find_column_case_insensitive(source_columns, default_column)
+
+        if matched_column:
+            return matched_column
+
+    fallback_column = find_column_case_insensitive(source_columns, "fsw")
+
+    if fallback_column:
+        return fallback_column
+
+    return source_columns[0]
+
+
 def find_matching_file(folder, source_code):
     folder_path = Path(folder)
     matches = sorted(folder_path.glob(f"{source_code}_*.csv"))
+
     if not matches:
         return None
+
     return matches[0]
 
 
@@ -101,46 +390,87 @@ def build_source_label(inventory_row, contributor_column, year_column):
 
     if contributor and year:
         return f"{contributor} ({year})"
+
     if contributor:
         return contributor
+
     if year:
         return year
+
     return ""
 
 
-def html_escape(value):
+def format_header(column_name):
+    special_headers = {
+        "fsw": "FSW",
+        "hamnosys_1_initial_configuration": "HamNoSys 1<br><span>Initial Configuration</span>",
+        "hamnosys_2_basic_handshape": "HamNoSys 2<br><span>Basic Handshape</span>",
+        "hamnosys_3_handshape_modifications": "HamNoSys 3<br><span>Handshape Modifications</span>",
+    }
+
+    if column_name in special_headers:
+        return special_headers[column_name]
+
+    return html.escape(column_name.replace("_", " ").title())
+
+
+def format_cell_value(value):
+    value = str(value).strip()
+
+    if value == "":
+        return '<span class="empty-cell">—</span>'
+
+    return html.escape(value)
+
+
+def column_class_name(column_name):
+    return f"col-{column_name.replace('_', '-').lower()}"
+
+
+def render_search_box():
     return (
-        str(value)
-        .replace("&", "&amp;")
-        .replace("<", "&lt;")
-        .replace(">", "&gt;")
-        .replace('"', "&quot;")
+        '<input id="table-search" class="table-search" type="search" '
+        'placeholder="Type to filter rows...">'
     )
 
 
-def format_header(column_name):
-    return column_name.replace("_", " ").title()
+def render_site_nav():
+    return """
+<nav class="site-nav">
+  <a href="../index.html">Home</a>
+  <a href="../segments.html">Segments</a>
+  <a href="../inventories.html">Inventories</a>
+  <a href="../languages.html">Languages</a>
+</nav>
+"""
 
 
 def render_segment_details(segment_row, columns_to_show):
     parts = []
-    parts.append("<table border='1' cellspacing='0' cellpadding='6'>")
-    parts.append("<tbody>")
+    parts.append('<div class="metadata-table-container">')
+    parts.append('<table class="metadata-table">')
+    parts.append("<thead><tr>")
 
     for col in columns_to_show:
-        value = html_escape(segment_row.get(col, ""))
+        column_class = column_class_name(col)
+        parts.append(f'<th class="{column_class}">{format_header(col)}</th>')
 
-        parts.append("<tr>")
-        parts.append(f"<th>{html_escape(format_header(col))}</th>")
+    parts.append("</tr></thead>")
+    parts.append("<tbody><tr>")
+
+    for col in columns_to_show:
+        value = format_cell_value(segment_row.get(col, ""))
+        column_class = column_class_name(col)
 
         if col.startswith("signwriting"):
-            parts.append(f'<td class="signwriting">{value}</td>')
+            parts.append(f'<td class="signwriting {column_class}">{value}</td>')
         else:
-            parts.append(f"<td>{value}</td>")
+            parts.append(f'<td class="{column_class}">{value}</td>')
 
-        parts.append("</tr>")
+    parts.append("</tr></tbody>")
+    parts.append("</table>")
+    parts.append("</div>")
 
-    parts.append("</tbody></table>")
     return "\n".join(parts)
 
 
@@ -155,52 +485,67 @@ def render_inventory_table(
         return "<p>No inventories found for this segment.</p>"
 
     parts = []
-    parts.append("<table border='1' cellspacing='0' cellpadding='6'>")
+    parts.append(render_search_box())
+    parts.append('<div class="table-container">')
+    parts.append('<table class="filterable-table">')
     parts.append("<thead><tr>")
-    parts.append("<th>Inventory</th>")
-    parts.append("<th>Language</th>")
-    parts.append("<th>Source</th>")
+    parts.append('<th class="col-inventory">Inventory</th>')
+    parts.append('<th class="col-language">Language</th>')
+    parts.append('<th class="col-source">Source</th>')
     parts.append("</tr></thead>")
     parts.append("<tbody>")
 
     for row in matching_inventories:
-        inv_id = row.get(inventory_id_column, "")
-        inv_name = row.get(inventory_name_column, "")
-        language = row.get(language_name_column, "")
-        source = row.get(source_label_column, "")
+        inv_id = row.get(inventory_id_column, "").strip()
+        inv_name = row.get(inventory_name_column, "").strip()
+        language = row.get(language_name_column, "").strip()
+        source = row.get(source_label_column, "").strip()
 
         link = f"../inventories/{inv_id}.html"
 
         parts.append("<tr>")
-        parts.append(f'<td><a href="{html_escape(link)}">{html_escape(inv_name)}</a></td>')
-        parts.append(f"<td>{html_escape(language)}</td>")
-        parts.append(f"<td>{html_escape(source)}</td>")
+        parts.append(f'<td class="col-inventory"><a href="{html.escape(link)}">{format_cell_value(inv_name)}</a></td>')
+        parts.append(f'<td class="col-language">{format_cell_value(language)}</td>')
+        parts.append(f'<td class="col-source">{format_cell_value(source)}</td>')
         parts.append("</tr>")
 
     parts.append("</tbody></table>")
+    parts.append("</div>")
+
     return "\n".join(parts)
 
 
 def write_segment_page(output_path, title, details_html, inventory_table_html):
+    description = "This page lists the details for a single segment and the inventories that contain it."
+
     page = f"""<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{html_escape(title)}</title>
-  {SIGNWRITING_FONT_CSS}
+  <title>Segment: {html.escape(title)}</title>
+  {PAGE_CSS}
 </head>
 <body>
-  <h1>{html_escape(title)}</h1>
+  <main class="page">
+    {render_site_nav()}
 
-  <h2>Segment Details</h2>
-  {details_html}
+    <section class="content-card">
+      <h1>Segment: {html.escape(title)}</h1>
+      {details_html}
+      <p class="page-description">{html.escape(description)}</p>
+    </section>
 
-  <h2>Inventories Containing This Segment</h2>
-  {inventory_table_html}
+    <section class="content-card">
+      <h2>Inventories Containing This Segment</h2>
+      {inventory_table_html}
+    </section>
+  </main>
+  {TABLE_FILTER_SCRIPT}
 </body>
 </html>
 """
+
     out = Path(output_path)
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(page, encoding="utf-8")
@@ -212,13 +557,12 @@ def get_known_defaults(segments_csv, inventories_csv):
 
     if seg_norm.endswith("segments.csv") and inv_norm.endswith("inventories.csv"):
         return {
-            "output_folder": "segments",
+            "output_folder": "docs/segments",
             "segment_id_column": "segment_id",
             "segment_fsw_column": "fsw",
             "segment_class_column": "segment_class",
             "segment_detail_columns": [
                 "segment_id",
-                "segment_class",
                 "hamnosys_1_initial_configuration",
                 "hamnosys_2_basic_handshape",
                 "hamnosys_3_handshape_modifications",
@@ -238,20 +582,123 @@ def get_known_defaults(segments_csv, inventories_csv):
     return None
 
 
+def get_settings_from_defaults(segment_columns, inventory_columns, defaults):
+    print("\nDetected known CSV files.")
+    print("Press Enter to keep each default, or type a replacement value.")
+
+    output_folder = prompt_with_default(
+        "Output folder for segment pages",
+        defaults["output_folder"],
+    )
+
+    print("\n--- segments.csv columns ---")
+    show_columns(segment_columns)
+
+    segment_id_column = prompt_column_with_default(
+        segment_columns,
+        "Segment ID column from segments.csv",
+        defaults["segment_id_column"],
+    )
+
+    segment_fsw_column = prompt_column_with_default(
+        segment_columns,
+        "FSW column from segments.csv",
+        defaults["segment_fsw_column"],
+    )
+
+    segment_class_column = prompt_column_with_default(
+        segment_columns,
+        "Segment class column from segments.csv",
+        defaults["segment_class_column"],
+    )
+
+    segment_detail_columns = prompt_columns_with_default(
+        segment_columns,
+        "Columns to show in the segment details table",
+        defaults["segment_detail_columns"],
+    )
+
+    print("\n--- inventories.csv columns ---")
+    show_columns(inventory_columns)
+
+    inventory_id_column = prompt_column_with_default(
+        inventory_columns,
+        "Inventory ID column from inventories.csv",
+        defaults["inventory_id_column"],
+    )
+
+    inventory_name_column = prompt_column_with_default(
+        inventory_columns,
+        "Inventory name column from inventories.csv",
+        defaults["inventory_name_column"],
+    )
+
+    language_name_column = prompt_column_with_default(
+        inventory_columns,
+        "Language name column from inventories.csv",
+        defaults["language_name_column"],
+    )
+
+    contributor_column = prompt_column_with_default(
+        inventory_columns,
+        "Contributor column from inventories.csv",
+        defaults["contributor_column"],
+    )
+
+    year_column = prompt_column_with_default(
+        inventory_columns,
+        "Year column from inventories.csv",
+        defaults["year_column"],
+    )
+
+    data_source_column = prompt_column_with_default(
+        inventory_columns,
+        "Data source column from inventories.csv",
+        defaults["data_source_column"],
+    )
+
+    data_source_location_column = prompt_column_with_default(
+        inventory_columns,
+        "Data source location column from inventories.csv",
+        defaults["data_source_location_column"],
+    )
+
+    return {
+        "output_folder": output_folder,
+        "segment_id_column": segment_id_column,
+        "segment_fsw_column": segment_fsw_column,
+        "segment_class_column": segment_class_column,
+        "segment_detail_columns": segment_detail_columns,
+        "inventory_id_column": inventory_id_column,
+        "inventory_name_column": inventory_name_column,
+        "language_name_column": language_name_column,
+        "contributor_column": contributor_column,
+        "year_column": year_column,
+        "data_source_column": data_source_column,
+        "data_source_location_column": data_source_location_column,
+    }
+
+
+def choose_known_csv_paths():
+    segments_csv = prompt_with_default(
+        "Segments CSV path",
+        "data/slphoible/segments.csv",
+    )
+
+    inventories_csv = prompt_with_default(
+        "Inventories CSV path",
+        "data/slphoible/inventories.csv",
+    )
+
+    return segments_csv, inventories_csv
+
+
 def main():
     print()
     print("This program creates individual segment HTML pages from segments.csv.")
     print("Each segment page shows the segment details and the inventories that contain that segment.")
 
-    segments_csv = input(
-        "\nEnter the path to the segments CSV "
-        "(for example: data/slphoible/segments.csv): "
-    ).strip()
-
-    inventories_csv = input(
-        "Enter the path to the inventories CSV "
-        "(for example: data/slphoible/inventories.csv): "
-    ).strip()
+    segments_csv, inventories_csv = choose_known_csv_paths()
 
     segments_rows = load_csv(segments_csv)
     inventories_rows = load_csv(inventories_csv)
@@ -259,6 +706,7 @@ def main():
     if not segments_rows:
         print("Segments CSV is empty.")
         return
+
     if not inventories_rows:
         print("Inventories CSV is empty.")
         return
@@ -268,90 +716,29 @@ def main():
 
     defaults = get_known_defaults(segments_csv, inventories_csv)
 
-    if defaults:
-        print("\nDetected known CSV files.")
-        print(f"\nSuggested output folder: {defaults['output_folder']}")
+    if not defaults:
+        print("\nNo defaults found for the selected CSV files.")
+        print("Add these CSV files to get_known_defaults() before generating segment pages.")
+        return
 
-        print("\nSuggested default columns from segments.csv:")
-        print(f"  ID column: {defaults['segment_id_column']}")
-        print(f"  FSW column: {defaults['segment_fsw_column']}")
-        print(f"  Segment class column: {defaults['segment_class_column']}")
-        print("  Segment detail columns: " + ", ".join(defaults["segment_detail_columns"]))
+    settings = get_settings_from_defaults(
+        segment_columns=segment_columns,
+        inventory_columns=inventory_columns,
+        defaults=defaults,
+    )
 
-        print("\nSuggested default columns from inventories.csv:")
-        print(f"  Inventory ID column: {defaults['inventory_id_column']}")
-        print(f"  Inventory name column: {defaults['inventory_name_column']}")
-        print(f"  Language name column: {defaults['language_name_column']}")
-        print(f"  Contributor column: {defaults['contributor_column']}")
-        print(f"  Year column: {defaults['year_column']}")
-        print(f"  Data source column: {defaults['data_source_column']}")
-        print(f"  Data source location column: {defaults['data_source_location_column']}")
-
-        use_defaults = input("\nUse these defaults? (y/n): ").strip().lower()
-
-        if use_defaults == "y":
-            output_folder = defaults["output_folder"]
-            segment_id_column = defaults["segment_id_column"]
-            segment_fsw_column = defaults["segment_fsw_column"]
-            segment_class_column = defaults["segment_class_column"]
-            segment_detail_columns = defaults["segment_detail_columns"]
-            inventory_id_column = defaults["inventory_id_column"]
-            inventory_name_column = defaults["inventory_name_column"]
-            language_name_column = defaults["language_name_column"]
-            contributor_column = defaults["contributor_column"]
-            year_column = defaults["year_column"]
-            data_source_column = defaults["data_source_column"]
-            data_source_location_column = defaults["data_source_location_column"]
-        else:
-            output_folder = input(
-                "\nEnter the output folder for the segment pages "
-                "(for example: segments): "
-            ).strip()
-
-            print("\n--- segments.csv columns ---")
-            show_columns(segment_columns)
-            segment_id_column = choose_one_column(segment_columns, "Select the segment ID column from segments.csv")
-            segment_fsw_column = choose_one_column(segment_columns, "Select the FSW column from segments.csv")
-            segment_class_column = choose_one_column(segment_columns, "Select the segment class column from segments.csv")
-            segment_detail_columns = choose_columns(
-                segment_columns,
-                "Enter the column numbers to show in the segment details table, separated by commas:"
-            )
-
-            print("\n--- inventories.csv columns ---")
-            show_columns(inventory_columns)
-            inventory_id_column = choose_one_column(inventory_columns, "Select the inventory ID column from inventories.csv")
-            inventory_name_column = choose_one_column(inventory_columns, "Select the inventory name column from inventories.csv")
-            language_name_column = choose_one_column(inventory_columns, "Select the language name column from inventories.csv")
-            contributor_column = choose_one_column(inventory_columns, "Select the contributor column from inventories.csv")
-            year_column = choose_one_column(inventory_columns, "Select the year column from inventories.csv")
-            data_source_column = choose_one_column(inventory_columns, "Select the data source column from inventories.csv")
-            data_source_location_column = choose_one_column(inventory_columns, "Select the data source location column from inventories.csv")
-    else:
-        output_folder = input(
-            "\nEnter the output folder for the segment pages "
-            "(for example: segments): "
-        ).strip()
-
-        print("\n--- segments.csv columns ---")
-        show_columns(segment_columns)
-        segment_id_column = choose_one_column(segment_columns, "Select the segment ID column from segments.csv")
-        segment_fsw_column = choose_one_column(segment_columns, "Select the FSW column from segments.csv")
-        segment_class_column = choose_one_column(segment_columns, "Select the segment class column from segments.csv")
-        segment_detail_columns = choose_columns(
-            segment_columns,
-            "Enter the column numbers to show in the segment details table, separated by commas:"
-        )
-
-        print("\n--- inventories.csv columns ---")
-        show_columns(inventory_columns)
-        inventory_id_column = choose_one_column(inventory_columns, "Select the inventory ID column from inventories.csv")
-        inventory_name_column = choose_one_column(inventory_columns, "Select the inventory name column from inventories.csv")
-        language_name_column = choose_one_column(inventory_columns, "Select the language name column from inventories.csv")
-        contributor_column = choose_one_column(inventory_columns, "Select the contributor column from inventories.csv")
-        year_column = choose_one_column(inventory_columns, "Select the year column from inventories.csv")
-        data_source_column = choose_one_column(inventory_columns, "Select the data source column from inventories.csv")
-        data_source_location_column = choose_one_column(inventory_columns, "Select the data source location column from inventories.csv")
+    output_folder = settings["output_folder"]
+    segment_id_column = settings["segment_id_column"]
+    segment_fsw_column = settings["segment_fsw_column"]
+    segment_class_column = settings["segment_class_column"]
+    segment_detail_columns = settings["segment_detail_columns"]
+    inventory_id_column = settings["inventory_id_column"]
+    inventory_name_column = settings["inventory_name_column"]
+    language_name_column = settings["language_name_column"]
+    contributor_column = settings["contributor_column"]
+    year_column = settings["year_column"]
+    data_source_column = settings["data_source_column"]
+    data_source_location_column = settings["data_source_location_column"]
 
     valid_segments = [
         row for row in segments_rows
@@ -366,11 +753,13 @@ def main():
     if not valid_segments:
         print("No valid segment rows found.")
         return
+
     if not valid_inventories:
         print("No valid inventory rows found.")
         return
 
     print("\n--- Valid segments ---")
+
     for i, row in enumerate(valid_segments, start=1):
         print(
             f"{i}. {row.get(segment_id_column, '')} | "
@@ -383,8 +772,8 @@ def main():
     print("  0   = none")
     print("  1-5 = range")
     print("  1,4,7 = specific entries")
-    selection = input("> ").strip().lower()
 
+    selection = input("> ").strip().lower()
     chosen_indexes = parse_selection(selection, len(valid_segments))
     selected_segments = [valid_segments[i] for i in chosen_indexes]
 
@@ -393,16 +782,18 @@ def main():
         return
 
     inventories_by_family = {}
+
     for row in valid_inventories:
         source_code = row.get(data_source_column, "").strip()
         family = get_source_family(source_code)
         inventories_by_family.setdefault(family, []).append(row)
 
-    family_fsw_columns = {}
+    family_segment_columns = {}
 
     for family in sorted(inventories_by_family.keys()):
         family_rows = inventories_by_family[family]
         sample_row = family_rows[0]
+
         sample_file = find_matching_file(
             sample_row.get(data_source_location_column, "").strip(),
             sample_row.get(data_source_column, "").strip(),
@@ -413,6 +804,7 @@ def main():
             continue
 
         sample_rows = load_csv(sample_file)
+
         if not sample_rows:
             print(f"\nSkipping source family {family}: sample file is empty.")
             continue
@@ -421,36 +813,45 @@ def main():
 
         print(f"\n--- Columns for source family: {family} ---")
         show_columns(source_columns)
-        family_fsw_columns[family] = choose_one_column(
+
+        default_source_segment_column = get_default_source_segment_column(
+            family,
             source_columns,
-            f"Select the FSW column for all {family} source files"
         )
 
-    inventory_fsw_lookup = {}
+        family_segment_columns[family] = prompt_column_with_default(
+            source_columns,
+            f"Source column containing segment values for all {family} source files",
+            default_source_segment_column,
+        )
+
+    inventory_segment_lookup = {}
 
     print("\nScanning inventory files...")
+
     for inv in valid_inventories:
         source_code = inv.get(data_source_column, "").strip()
         source_folder = inv.get(data_source_location_column, "").strip()
         family = get_source_family(source_code)
 
         source_file = find_matching_file(source_folder, source_code)
+
         if not source_file:
             continue
 
-        if family not in family_fsw_columns:
+        if family not in family_segment_columns:
             continue
 
         source_rows = load_csv(source_file)
-        fsw_column = family_fsw_columns[family]
+        source_segment_column = family_segment_columns[family]
 
-        fsw_values = {
-            row.get(fsw_column, "").strip()
+        segment_values = {
+            row.get(source_segment_column, "").strip()
             for row in source_rows
-            if row.get(fsw_column, "").strip() != ""
+            if row.get(source_segment_column, "").strip() != ""
         }
 
-        inventory_fsw_lookup[inv.get(inventory_id_column, "")] = fsw_values
+        inventory_segment_lookup[inv.get(inventory_id_column, "")] = segment_values
 
     source_label_column = "_source_label_temp"
 
@@ -465,14 +866,17 @@ def main():
         segment_class = segment_row.get(segment_class_column, "").strip()
 
         matching_inventories = []
+
         for inv in valid_inventories:
             inv_id = inv.get(inventory_id_column, "")
-            inv_fsw_values = inventory_fsw_lookup.get(inv_id, set())
-            if segment_fsw in inv_fsw_values:
+            inv_segment_values = inventory_segment_lookup.get(inv_id, set())
+
+            if segment_fsw in inv_segment_values:
                 matching_inventories.append(inv)
 
         title = f"{segment_class.capitalize()} {segment_fsw}" if segment_class else segment_fsw
         details_html = render_segment_details(segment_row, segment_detail_columns)
+
         inventory_table_html = render_inventory_table(
             matching_inventories,
             inventory_id_column=inventory_id_column,


### PR DESCRIPTION
Updates the scripts that build individual detail pages so inventory, segment, and language pages use the CSS-styled layout used across the main website pages.

Overall updates:
- Update `ibuilder.py`, `sbuilder.py`, and `lbuilder.py` so individual pages are written under `docs/inventories/`, `docs/segments/`, and `docs/languages/`
- Update `ibuilder.py`, `sbuilder.py`, and `lbuilder.py` so individual pages are generated with CSS styling instead of plain HTML tables
- Regenerate individual inventory, segment, and language pages with the updated scripts

Style page changes from `ibuilder.py`,`sbuilder.py`, and `lbuilder.py` include:
- Add navigation links to the other main pages
- Add styled inventory detail cards and segment tables
- Add compact inventory metadata rows
- Add page description
- Add data note disclaimer about source-derived inventory data (to Inventory pages only) - Closes #18
- Add searchable data tables
- Add sticky table headers
- Add clearer display headers for HamNoSys and ISO 639-3 columns
- Improve wrapping for long table values
- Show empty cells with muted dash markers
- Remove repetitive information from detail cards when it already appears elsewhere

Builder workflow changes:
- Replace the all-or-nothing default choice with individual override prompts for each default setting
- Replace the “first N pages” inventory prompt with choice of specific inventory pages (`ibuilder.py` only)
- Add source-file column defaults: `FSW` for LQ and `Handshape` for SP (`ibuilder.py` and `sbuilder.py`)
- Only ask whether to continue with exact language-name matching when discrepancies are found (`lbuilder.py` only)

Closes #18.
Closes #22.