### PR TITLE
fix(pages): improve mobile page layout

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -86,6 +86,55 @@ a:hover {
 ul {
   padding-left: 1.5rem;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1 {
+    font-size: 1.5rem;
+    line-height: 1.2;
+  }
+
+  h2 {
+    font-size: 1.35rem;
+    line-height: 1.2;
+  }
+
+  h3 {
+    font-size: 1.15rem;
+    line-height: 1.2;
+  }
+
+  .page-description,
+  p,
+  li {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  ul {
+    padding-left: 1.25rem;
+  }
+}
   </style>
 </head>
 

--- a/docs/inventories.html
+++ b/docs/inventories.html
@@ -196,6 +196,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00001.html
+++ b/docs/inventories/inv00001.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00002.html
+++ b/docs/inventories/inv00002.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00003.html
+++ b/docs/inventories/inv00003.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00004.html
+++ b/docs/inventories/inv00004.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00005.html
+++ b/docs/inventories/inv00005.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00006.html
+++ b/docs/inventories/inv00006.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00007.html
+++ b/docs/inventories/inv00007.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00008.html
+++ b/docs/inventories/inv00008.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00009.html
+++ b/docs/inventories/inv00009.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00010.html
+++ b/docs/inventories/inv00010.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00011.html
+++ b/docs/inventories/inv00011.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00012.html
+++ b/docs/inventories/inv00012.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00013.html
+++ b/docs/inventories/inv00013.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00014.html
+++ b/docs/inventories/inv00014.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00015.html
+++ b/docs/inventories/inv00015.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00016.html
+++ b/docs/inventories/inv00016.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00017.html
+++ b/docs/inventories/inv00017.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00018.html
+++ b/docs/inventories/inv00018.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00019.html
+++ b/docs/inventories/inv00019.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00020.html
+++ b/docs/inventories/inv00020.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00021.html
+++ b/docs/inventories/inv00021.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00022.html
+++ b/docs/inventories/inv00022.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00023.html
+++ b/docs/inventories/inv00023.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00024.html
+++ b/docs/inventories/inv00024.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00025.html
+++ b/docs/inventories/inv00025.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00026.html
+++ b/docs/inventories/inv00026.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00027.html
+++ b/docs/inventories/inv00027.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00028.html
+++ b/docs/inventories/inv00028.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00029.html
+++ b/docs/inventories/inv00029.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00030.html
+++ b/docs/inventories/inv00030.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00031.html
+++ b/docs/inventories/inv00031.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00032.html
+++ b/docs/inventories/inv00032.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00033.html
+++ b/docs/inventories/inv00033.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00034.html
+++ b/docs/inventories/inv00034.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00035.html
+++ b/docs/inventories/inv00035.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00036.html
+++ b/docs/inventories/inv00036.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00037.html
+++ b/docs/inventories/inv00037.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00038.html
+++ b/docs/inventories/inv00038.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00039.html
+++ b/docs/inventories/inv00039.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00040.html
+++ b/docs/inventories/inv00040.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00041.html
+++ b/docs/inventories/inv00041.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00042.html
+++ b/docs/inventories/inv00042.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00043.html
+++ b/docs/inventories/inv00043.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00044.html
+++ b/docs/inventories/inv00044.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00045.html
+++ b/docs/inventories/inv00045.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00046.html
+++ b/docs/inventories/inv00046.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00047.html
+++ b/docs/inventories/inv00047.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00048.html
+++ b/docs/inventories/inv00048.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00049.html
+++ b/docs/inventories/inv00049.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00050.html
+++ b/docs/inventories/inv00050.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00051.html
+++ b/docs/inventories/inv00051.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00052.html
+++ b/docs/inventories/inv00052.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00053.html
+++ b/docs/inventories/inv00053.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00054.html
+++ b/docs/inventories/inv00054.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00055.html
+++ b/docs/inventories/inv00055.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00056.html
+++ b/docs/inventories/inv00056.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00057.html
+++ b/docs/inventories/inv00057.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00058.html
+++ b/docs/inventories/inv00058.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00059.html
+++ b/docs/inventories/inv00059.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00060.html
+++ b/docs/inventories/inv00060.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00061.html
+++ b/docs/inventories/inv00061.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00062.html
+++ b/docs/inventories/inv00062.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00063.html
+++ b/docs/inventories/inv00063.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00064.html
+++ b/docs/inventories/inv00064.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00065.html
+++ b/docs/inventories/inv00065.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00066.html
+++ b/docs/inventories/inv00066.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00067.html
+++ b/docs/inventories/inv00067.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00068.html
+++ b/docs/inventories/inv00068.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00069.html
+++ b/docs/inventories/inv00069.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00070.html
+++ b/docs/inventories/inv00070.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00071.html
+++ b/docs/inventories/inv00071.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00072.html
+++ b/docs/inventories/inv00072.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00073.html
+++ b/docs/inventories/inv00073.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00074.html
+++ b/docs/inventories/inv00074.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00075.html
+++ b/docs/inventories/inv00075.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00076.html
+++ b/docs/inventories/inv00076.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00077.html
+++ b/docs/inventories/inv00077.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00078.html
+++ b/docs/inventories/inv00078.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00079.html
+++ b/docs/inventories/inv00079.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00080.html
+++ b/docs/inventories/inv00080.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00081.html
+++ b/docs/inventories/inv00081.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00082.html
+++ b/docs/inventories/inv00082.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00083.html
+++ b/docs/inventories/inv00083.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00084.html
+++ b/docs/inventories/inv00084.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00085.html
+++ b/docs/inventories/inv00085.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00086.html
+++ b/docs/inventories/inv00086.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00087.html
+++ b/docs/inventories/inv00087.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00088.html
+++ b/docs/inventories/inv00088.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00089.html
+++ b/docs/inventories/inv00089.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00090.html
+++ b/docs/inventories/inv00090.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00091.html
+++ b/docs/inventories/inv00091.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00092.html
+++ b/docs/inventories/inv00092.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00093.html
+++ b/docs/inventories/inv00093.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/inventories/inv00094.html
+++ b/docs/inventories/inv00094.html
@@ -217,6 +217,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages.html
+++ b/docs/languages.html
@@ -196,6 +196,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00001.html
+++ b/docs/languages/lan00001.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00002.html
+++ b/docs/languages/lan00002.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00003.html
+++ b/docs/languages/lan00003.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00004.html
+++ b/docs/languages/lan00004.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00005.html
+++ b/docs/languages/lan00005.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00006.html
+++ b/docs/languages/lan00006.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00007.html
+++ b/docs/languages/lan00007.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00008.html
+++ b/docs/languages/lan00008.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00009.html
+++ b/docs/languages/lan00009.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00010.html
+++ b/docs/languages/lan00010.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00011.html
+++ b/docs/languages/lan00011.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00012.html
+++ b/docs/languages/lan00012.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00013.html
+++ b/docs/languages/lan00013.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00014.html
+++ b/docs/languages/lan00014.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00015.html
+++ b/docs/languages/lan00015.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00016.html
+++ b/docs/languages/lan00016.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00017.html
+++ b/docs/languages/lan00017.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00018.html
+++ b/docs/languages/lan00018.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00019.html
+++ b/docs/languages/lan00019.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00020.html
+++ b/docs/languages/lan00020.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00021.html
+++ b/docs/languages/lan00021.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00022.html
+++ b/docs/languages/lan00022.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00023.html
+++ b/docs/languages/lan00023.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00024.html
+++ b/docs/languages/lan00024.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00025.html
+++ b/docs/languages/lan00025.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00026.html
+++ b/docs/languages/lan00026.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00027.html
+++ b/docs/languages/lan00027.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00028.html
+++ b/docs/languages/lan00028.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00029.html
+++ b/docs/languages/lan00029.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00030.html
+++ b/docs/languages/lan00030.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00031.html
+++ b/docs/languages/lan00031.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00032.html
+++ b/docs/languages/lan00032.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00033.html
+++ b/docs/languages/lan00033.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00034.html
+++ b/docs/languages/lan00034.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00035.html
+++ b/docs/languages/lan00035.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00036.html
+++ b/docs/languages/lan00036.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00037.html
+++ b/docs/languages/lan00037.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00038.html
+++ b/docs/languages/lan00038.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00039.html
+++ b/docs/languages/lan00039.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00040.html
+++ b/docs/languages/lan00040.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00041.html
+++ b/docs/languages/lan00041.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00042.html
+++ b/docs/languages/lan00042.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00043.html
+++ b/docs/languages/lan00043.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00044.html
+++ b/docs/languages/lan00044.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00045.html
+++ b/docs/languages/lan00045.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00046.html
+++ b/docs/languages/lan00046.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00047.html
+++ b/docs/languages/lan00047.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00048.html
+++ b/docs/languages/lan00048.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00049.html
+++ b/docs/languages/lan00049.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00050.html
+++ b/docs/languages/lan00050.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00051.html
+++ b/docs/languages/lan00051.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00052.html
+++ b/docs/languages/lan00052.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00053.html
+++ b/docs/languages/lan00053.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00054.html
+++ b/docs/languages/lan00054.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00055.html
+++ b/docs/languages/lan00055.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00056.html
+++ b/docs/languages/lan00056.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00057.html
+++ b/docs/languages/lan00057.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00058.html
+++ b/docs/languages/lan00058.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00059.html
+++ b/docs/languages/lan00059.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00060.html
+++ b/docs/languages/lan00060.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00061.html
+++ b/docs/languages/lan00061.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00062.html
+++ b/docs/languages/lan00062.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00063.html
+++ b/docs/languages/lan00063.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00064.html
+++ b/docs/languages/lan00064.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00065.html
+++ b/docs/languages/lan00065.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00066.html
+++ b/docs/languages/lan00066.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00067.html
+++ b/docs/languages/lan00067.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00068.html
+++ b/docs/languages/lan00068.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00069.html
+++ b/docs/languages/lan00069.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00070.html
+++ b/docs/languages/lan00070.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00071.html
+++ b/docs/languages/lan00071.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00072.html
+++ b/docs/languages/lan00072.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00073.html
+++ b/docs/languages/lan00073.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00074.html
+++ b/docs/languages/lan00074.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00075.html
+++ b/docs/languages/lan00075.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00076.html
+++ b/docs/languages/lan00076.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00077.html
+++ b/docs/languages/lan00077.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00078.html
+++ b/docs/languages/lan00078.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00079.html
+++ b/docs/languages/lan00079.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00080.html
+++ b/docs/languages/lan00080.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00081.html
+++ b/docs/languages/lan00081.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00082.html
+++ b/docs/languages/lan00082.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00083.html
+++ b/docs/languages/lan00083.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00084.html
+++ b/docs/languages/lan00084.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/languages/lan00085.html
+++ b/docs/languages/lan00085.html
@@ -187,6 +187,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments.html
+++ b/docs/segments.html
@@ -196,6 +196,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>
@@ -216,9 +285,9 @@ a:hover {
 <table>
 <thead><tr>
 <th class="col-segment-class">Segment Class</th>
-<th class="col-hamnosys-1-initial-configuration">HamNoSys 1<br><span>Initial Configuration</span></th>
-<th class="col-hamnosys-2-basic-handshape">HamNoSys 2<br><span>Basic Handshape</span></th>
-<th class="col-hamnosys-3-handshape-modifications">HamNoSys 3<br><span>Handshape Modifications</span></th>
+<th class="col-hamnosys-1-initial-configuration">HamNoSys&nbsp;1<br><span>Initial Configuration</span></th>
+<th class="col-hamnosys-2-basic-handshape">HamNoSys&nbsp;2<br><span>Basic Handshape</span></th>
+<th class="col-hamnosys-3-handshape-modifications">HamNoSys&nbsp;3<br><span>Handshape Modifications</span></th>
 <th class="col-fsw">FSW</th>
 <th class="col-signwriting-1">Signwriting 1</th>
 <th class="col-signwriting-2">Signwriting 2</th>

--- a/docs/segments/seg00001.html
+++ b/docs/segments/seg00001.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00002.html
+++ b/docs/segments/seg00002.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00003.html
+++ b/docs/segments/seg00003.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00004.html
+++ b/docs/segments/seg00004.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00005.html
+++ b/docs/segments/seg00005.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00006.html
+++ b/docs/segments/seg00006.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00007.html
+++ b/docs/segments/seg00007.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00008.html
+++ b/docs/segments/seg00008.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00009.html
+++ b/docs/segments/seg00009.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00010.html
+++ b/docs/segments/seg00010.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00011.html
+++ b/docs/segments/seg00011.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00012.html
+++ b/docs/segments/seg00012.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00013.html
+++ b/docs/segments/seg00013.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00014.html
+++ b/docs/segments/seg00014.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00015.html
+++ b/docs/segments/seg00015.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00016.html
+++ b/docs/segments/seg00016.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00017.html
+++ b/docs/segments/seg00017.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00018.html
+++ b/docs/segments/seg00018.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00019.html
+++ b/docs/segments/seg00019.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00020.html
+++ b/docs/segments/seg00020.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00021.html
+++ b/docs/segments/seg00021.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00022.html
+++ b/docs/segments/seg00022.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00023.html
+++ b/docs/segments/seg00023.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00024.html
+++ b/docs/segments/seg00024.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00025.html
+++ b/docs/segments/seg00025.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00026.html
+++ b/docs/segments/seg00026.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00027.html
+++ b/docs/segments/seg00027.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00028.html
+++ b/docs/segments/seg00028.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00029.html
+++ b/docs/segments/seg00029.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00030.html
+++ b/docs/segments/seg00030.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00031.html
+++ b/docs/segments/seg00031.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00032.html
+++ b/docs/segments/seg00032.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00033.html
+++ b/docs/segments/seg00033.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00034.html
+++ b/docs/segments/seg00034.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00035.html
+++ b/docs/segments/seg00035.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00036.html
+++ b/docs/segments/seg00036.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00037.html
+++ b/docs/segments/seg00037.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00038.html
+++ b/docs/segments/seg00038.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00039.html
+++ b/docs/segments/seg00039.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00040.html
+++ b/docs/segments/seg00040.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00041.html
+++ b/docs/segments/seg00041.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00042.html
+++ b/docs/segments/seg00042.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00043.html
+++ b/docs/segments/seg00043.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00044.html
+++ b/docs/segments/seg00044.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00045.html
+++ b/docs/segments/seg00045.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00046.html
+++ b/docs/segments/seg00046.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00047.html
+++ b/docs/segments/seg00047.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00048.html
+++ b/docs/segments/seg00048.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00049.html
+++ b/docs/segments/seg00049.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00050.html
+++ b/docs/segments/seg00050.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00051.html
+++ b/docs/segments/seg00051.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00052.html
+++ b/docs/segments/seg00052.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00053.html
+++ b/docs/segments/seg00053.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00054.html
+++ b/docs/segments/seg00054.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00055.html
+++ b/docs/segments/seg00055.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00056.html
+++ b/docs/segments/seg00056.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00057.html
+++ b/docs/segments/seg00057.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00058.html
+++ b/docs/segments/seg00058.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00059.html
+++ b/docs/segments/seg00059.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00060.html
+++ b/docs/segments/seg00060.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00061.html
+++ b/docs/segments/seg00061.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00062.html
+++ b/docs/segments/seg00062.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00063.html
+++ b/docs/segments/seg00063.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00064.html
+++ b/docs/segments/seg00064.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00065.html
+++ b/docs/segments/seg00065.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00066.html
+++ b/docs/segments/seg00066.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00067.html
+++ b/docs/segments/seg00067.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00068.html
+++ b/docs/segments/seg00068.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00069.html
+++ b/docs/segments/seg00069.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00070.html
+++ b/docs/segments/seg00070.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00071.html
+++ b/docs/segments/seg00071.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00072.html
+++ b/docs/segments/seg00072.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00073.html
+++ b/docs/segments/seg00073.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00074.html
+++ b/docs/segments/seg00074.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00075.html
+++ b/docs/segments/seg00075.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00076.html
+++ b/docs/segments/seg00076.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00077.html
+++ b/docs/segments/seg00077.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00078.html
+++ b/docs/segments/seg00078.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00079.html
+++ b/docs/segments/seg00079.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00080.html
+++ b/docs/segments/seg00080.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00081.html
+++ b/docs/segments/seg00081.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00082.html
+++ b/docs/segments/seg00082.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00083.html
+++ b/docs/segments/seg00083.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00084.html
+++ b/docs/segments/seg00084.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00085.html
+++ b/docs/segments/seg00085.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00086.html
+++ b/docs/segments/seg00086.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00087.html
+++ b/docs/segments/seg00087.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00088.html
+++ b/docs/segments/seg00088.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00089.html
+++ b/docs/segments/seg00089.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00090.html
+++ b/docs/segments/seg00090.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00091.html
+++ b/docs/segments/seg00091.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00092.html
+++ b/docs/segments/seg00092.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00093.html
+++ b/docs/segments/seg00093.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00094.html
+++ b/docs/segments/seg00094.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00095.html
+++ b/docs/segments/seg00095.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00096.html
+++ b/docs/segments/seg00096.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00097.html
+++ b/docs/segments/seg00097.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00098.html
+++ b/docs/segments/seg00098.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00099.html
+++ b/docs/segments/seg00099.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00100.html
+++ b/docs/segments/seg00100.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00101.html
+++ b/docs/segments/seg00101.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00102.html
+++ b/docs/segments/seg00102.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00103.html
+++ b/docs/segments/seg00103.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00104.html
+++ b/docs/segments/seg00104.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00105.html
+++ b/docs/segments/seg00105.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00106.html
+++ b/docs/segments/seg00106.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00107.html
+++ b/docs/segments/seg00107.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00108.html
+++ b/docs/segments/seg00108.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00109.html
+++ b/docs/segments/seg00109.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00110.html
+++ b/docs/segments/seg00110.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00111.html
+++ b/docs/segments/seg00111.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00112.html
+++ b/docs/segments/seg00112.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00113.html
+++ b/docs/segments/seg00113.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00114.html
+++ b/docs/segments/seg00114.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00115.html
+++ b/docs/segments/seg00115.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00116.html
+++ b/docs/segments/seg00116.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00117.html
+++ b/docs/segments/seg00117.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00118.html
+++ b/docs/segments/seg00118.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00119.html
+++ b/docs/segments/seg00119.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00120.html
+++ b/docs/segments/seg00120.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00121.html
+++ b/docs/segments/seg00121.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00122.html
+++ b/docs/segments/seg00122.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00123.html
+++ b/docs/segments/seg00123.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00124.html
+++ b/docs/segments/seg00124.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00125.html
+++ b/docs/segments/seg00125.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00126.html
+++ b/docs/segments/seg00126.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00127.html
+++ b/docs/segments/seg00127.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00128.html
+++ b/docs/segments/seg00128.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00129.html
+++ b/docs/segments/seg00129.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00130.html
+++ b/docs/segments/seg00130.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00131.html
+++ b/docs/segments/seg00131.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00132.html
+++ b/docs/segments/seg00132.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00133.html
+++ b/docs/segments/seg00133.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00134.html
+++ b/docs/segments/seg00134.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00135.html
+++ b/docs/segments/seg00135.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00136.html
+++ b/docs/segments/seg00136.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00137.html
+++ b/docs/segments/seg00137.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00138.html
+++ b/docs/segments/seg00138.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00139.html
+++ b/docs/segments/seg00139.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00140.html
+++ b/docs/segments/seg00140.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00141.html
+++ b/docs/segments/seg00141.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00142.html
+++ b/docs/segments/seg00142.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00143.html
+++ b/docs/segments/seg00143.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00144.html
+++ b/docs/segments/seg00144.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00145.html
+++ b/docs/segments/seg00145.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00146.html
+++ b/docs/segments/seg00146.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00147.html
+++ b/docs/segments/seg00147.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00148.html
+++ b/docs/segments/seg00148.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00149.html
+++ b/docs/segments/seg00149.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00150.html
+++ b/docs/segments/seg00150.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00151.html
+++ b/docs/segments/seg00151.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00152.html
+++ b/docs/segments/seg00152.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00153.html
+++ b/docs/segments/seg00153.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00154.html
+++ b/docs/segments/seg00154.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00155.html
+++ b/docs/segments/seg00155.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00156.html
+++ b/docs/segments/seg00156.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00157.html
+++ b/docs/segments/seg00157.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00158.html
+++ b/docs/segments/seg00158.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00159.html
+++ b/docs/segments/seg00159.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00160.html
+++ b/docs/segments/seg00160.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00161.html
+++ b/docs/segments/seg00161.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00162.html
+++ b/docs/segments/seg00162.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00163.html
+++ b/docs/segments/seg00163.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00164.html
+++ b/docs/segments/seg00164.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00165.html
+++ b/docs/segments/seg00165.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00166.html
+++ b/docs/segments/seg00166.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00167.html
+++ b/docs/segments/seg00167.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00168.html
+++ b/docs/segments/seg00168.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00169.html
+++ b/docs/segments/seg00169.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00170.html
+++ b/docs/segments/seg00170.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00171.html
+++ b/docs/segments/seg00171.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00172.html
+++ b/docs/segments/seg00172.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00173.html
+++ b/docs/segments/seg00173.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00174.html
+++ b/docs/segments/seg00174.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00175.html
+++ b/docs/segments/seg00175.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00176.html
+++ b/docs/segments/seg00176.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00177.html
+++ b/docs/segments/seg00177.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00178.html
+++ b/docs/segments/seg00178.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00179.html
+++ b/docs/segments/seg00179.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00180.html
+++ b/docs/segments/seg00180.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00181.html
+++ b/docs/segments/seg00181.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00182.html
+++ b/docs/segments/seg00182.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00183.html
+++ b/docs/segments/seg00183.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00184.html
+++ b/docs/segments/seg00184.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00185.html
+++ b/docs/segments/seg00185.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00186.html
+++ b/docs/segments/seg00186.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00187.html
+++ b/docs/segments/seg00187.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00188.html
+++ b/docs/segments/seg00188.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00189.html
+++ b/docs/segments/seg00189.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00190.html
+++ b/docs/segments/seg00190.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00191.html
+++ b/docs/segments/seg00191.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00192.html
+++ b/docs/segments/seg00192.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00193.html
+++ b/docs/segments/seg00193.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00194.html
+++ b/docs/segments/seg00194.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00195.html
+++ b/docs/segments/seg00195.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00196.html
+++ b/docs/segments/seg00196.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00197.html
+++ b/docs/segments/seg00197.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00198.html
+++ b/docs/segments/seg00198.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00199.html
+++ b/docs/segments/seg00199.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00200.html
+++ b/docs/segments/seg00200.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00201.html
+++ b/docs/segments/seg00201.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00202.html
+++ b/docs/segments/seg00202.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00203.html
+++ b/docs/segments/seg00203.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00204.html
+++ b/docs/segments/seg00204.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00205.html
+++ b/docs/segments/seg00205.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00206.html
+++ b/docs/segments/seg00206.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00207.html
+++ b/docs/segments/seg00207.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00208.html
+++ b/docs/segments/seg00208.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00209.html
+++ b/docs/segments/seg00209.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00210.html
+++ b/docs/segments/seg00210.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00211.html
+++ b/docs/segments/seg00211.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00212.html
+++ b/docs/segments/seg00212.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00213.html
+++ b/docs/segments/seg00213.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00214.html
+++ b/docs/segments/seg00214.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00215.html
+++ b/docs/segments/seg00215.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00216.html
+++ b/docs/segments/seg00216.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00217.html
+++ b/docs/segments/seg00217.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00218.html
+++ b/docs/segments/seg00218.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00219.html
+++ b/docs/segments/seg00219.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00220.html
+++ b/docs/segments/seg00220.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00221.html
+++ b/docs/segments/seg00221.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00222.html
+++ b/docs/segments/seg00222.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00223.html
+++ b/docs/segments/seg00223.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00224.html
+++ b/docs/segments/seg00224.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00225.html
+++ b/docs/segments/seg00225.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00226.html
+++ b/docs/segments/seg00226.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00227.html
+++ b/docs/segments/seg00227.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00228.html
+++ b/docs/segments/seg00228.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00229.html
+++ b/docs/segments/seg00229.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00230.html
+++ b/docs/segments/seg00230.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00231.html
+++ b/docs/segments/seg00231.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00232.html
+++ b/docs/segments/seg00232.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00233.html
+++ b/docs/segments/seg00233.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00234.html
+++ b/docs/segments/seg00234.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00235.html
+++ b/docs/segments/seg00235.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00236.html
+++ b/docs/segments/seg00236.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00237.html
+++ b/docs/segments/seg00237.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00238.html
+++ b/docs/segments/seg00238.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00239.html
+++ b/docs/segments/seg00239.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00240.html
+++ b/docs/segments/seg00240.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00241.html
+++ b/docs/segments/seg00241.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00242.html
+++ b/docs/segments/seg00242.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00243.html
+++ b/docs/segments/seg00243.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00244.html
+++ b/docs/segments/seg00244.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00245.html
+++ b/docs/segments/seg00245.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00246.html
+++ b/docs/segments/seg00246.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00247.html
+++ b/docs/segments/seg00247.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00248.html
+++ b/docs/segments/seg00248.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00249.html
+++ b/docs/segments/seg00249.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00250.html
+++ b/docs/segments/seg00250.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00251.html
+++ b/docs/segments/seg00251.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00252.html
+++ b/docs/segments/seg00252.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00253.html
+++ b/docs/segments/seg00253.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00254.html
+++ b/docs/segments/seg00254.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00255.html
+++ b/docs/segments/seg00255.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00256.html
+++ b/docs/segments/seg00256.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00257.html
+++ b/docs/segments/seg00257.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00258.html
+++ b/docs/segments/seg00258.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00259.html
+++ b/docs/segments/seg00259.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00260.html
+++ b/docs/segments/seg00260.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00261.html
+++ b/docs/segments/seg00261.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00262.html
+++ b/docs/segments/seg00262.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00263.html
+++ b/docs/segments/seg00263.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00264.html
+++ b/docs/segments/seg00264.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00265.html
+++ b/docs/segments/seg00265.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00266.html
+++ b/docs/segments/seg00266.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00267.html
+++ b/docs/segments/seg00267.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00268.html
+++ b/docs/segments/seg00268.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00269.html
+++ b/docs/segments/seg00269.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00270.html
+++ b/docs/segments/seg00270.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00271.html
+++ b/docs/segments/seg00271.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00272.html
+++ b/docs/segments/seg00272.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00273.html
+++ b/docs/segments/seg00273.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00274.html
+++ b/docs/segments/seg00274.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00275.html
+++ b/docs/segments/seg00275.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00276.html
+++ b/docs/segments/seg00276.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00277.html
+++ b/docs/segments/seg00277.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/docs/segments/seg00278.html
+++ b/docs/segments/seg00278.html
@@ -212,6 +212,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 
 </head>

--- a/scripts/pages/generator.py
+++ b/scripts/pages/generator.py
@@ -194,6 +194,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 """
 
@@ -321,9 +390,9 @@ def format_header(column_name):
         "fsw": "FSW",
         "ISO-639-3": "ISO 639-3",
         "ct_handshapes": "Handshape<br><span>Count</span>",
-        "hamnosys_1_initial_configuration": "HamNoSys 1<br><span>Initial Configuration</span>",
-        "hamnosys_2_basic_handshape": "HamNoSys 2<br><span>Basic Handshape</span>",
-        "hamnosys_3_handshape_modifications": "HamNoSys 3<br><span>Handshape Modifications</span>",
+        "hamnosys_1_initial_configuration": "HamNoSys&nbsp;1<br><span>Initial Configuration</span>",
+        "hamnosys_2_basic_handshape": "HamNoSys&nbsp;2<br><span>Basic Handshape</span>",
+        "hamnosys_3_handshape_modifications": "HamNoSys&nbsp;3<br><span>Handshape Modifications</span>",
     }
 
     if column_name in special_headers:

--- a/scripts/pages/ibuilder.py
+++ b/scripts/pages/ibuilder.py
@@ -218,6 +218,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 """
 

--- a/scripts/pages/lbuilder.py
+++ b/scripts/pages/lbuilder.py
@@ -188,6 +188,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 """
 

--- a/scripts/pages/sbuilder.py
+++ b/scripts/pages/sbuilder.py
@@ -213,6 +213,75 @@ a:hover {
 .empty-cell {
   color: #aaa;
 }
+
+@media (max-width: 700px) {
+  .page {
+    max-width: 100%;
+    padding: 0.75rem;
+  }
+
+  .site-nav {
+    gap: 0.35rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .site-nav a {
+    font-size: 0.86rem;
+    padding: 0.39rem 0.64rem;
+  }
+
+  h1,
+  h2 {
+    font-size: 1.25rem;
+    line-height: 1.2;
+  }
+
+  .language-title {
+    max-width: 100%;
+  }
+
+  .title-extra {
+    font-size: 0.72em;
+  }
+
+  .page-description {
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+
+  .content-card {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 10px;
+  }
+
+  .table-search {
+    max-width: 100%;
+    font-size: 0.95rem;
+    padding: 0.6rem 0.75rem;
+  }
+
+  .table-container,
+  .metadata-table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  table {
+    min-width: 560px;
+  }
+
+  th,
+  td {
+    padding: 0.6rem 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .signwriting {
+    font-size: 1.5em;
+  }
+}
 </style>
 """
 


### PR DESCRIPTION
Update the page CSS so the website displays better on small screens, and regenerate the affected website pages with the updated scripts.

Apply shared mobile layout changes to `ibuilder.py`, `sbuilder.py`, `lbuilder.py`, and `generator.py`:
- Reduce page spacing, heading size, card padding, table cell spacing, and SignWriting size
- Adjust navigation link sizing so the site links fit better
- Keep tables horizontally scrollable inside their containers

Updates to `generator.py`:
- Prevent HamNoSys header numbers from wrapping awkwardly

Updates to `docs/index.html`:
- Add matching responsive styling